### PR TITLE
Fix MacOS Firmware Flashing

### DIFF
--- a/chameleonultragui/lib/bridge/dfu.dart
+++ b/chameleonultragui/lib/bridge/dfu.dart
@@ -261,7 +261,7 @@ class ChameleonDFU {
       validateCrc();
     }
 
-    if (Platform.isWindows) {
+    if (Platform.isWindows | Platform.isMacOS) {
       // Transmittion errors fix
       await _serialInstance!.read(16384);
     }
@@ -281,7 +281,7 @@ class ChameleonDFU {
     // We work around it by sending message by parts with delay
     var offsetSize = 128;
 
-    if (Platform.isWindows) {
+    if (Platform.isWindows | Platform.isMacOS) {
       for (var offset = 0; offset < packet.length; offset += offsetSize) {
         await _serialInstance!.write(packet.sublist(
             offset, offset + min(offsetSize, packet.length - offset)));

--- a/chameleonultragui/lib/bridge/dfu.dart
+++ b/chameleonultragui/lib/bridge/dfu.dart
@@ -261,7 +261,7 @@ class ChameleonDFU {
       validateCrc();
     }
 
-    if (Platform.isWindows | Platform.isMacOS) {
+    if (Platform.isWindows || Platform.isMacOS) {
       // Transmittion errors fix
       await _serialInstance!.read(16384);
     }
@@ -281,7 +281,7 @@ class ChameleonDFU {
     // We work around it by sending message by parts with delay
     var offsetSize = 128;
 
-    if (Platform.isWindows | Platform.isMacOS) {
+    if (Platform.isWindows || Platform.isMacOS) {
       for (var offset = 0; offset < packet.length; offset += offsetSize) {
         await _serialInstance!.write(packet.sublist(
             offset, offset + min(offsetSize, packet.length - offset)));


### PR DESCRIPTION
Applies the same fix from the Windows flashing process across to MacOS. I've tested this on MacOS and it's now working rather than getting stuck during the update process. 