### PR TITLE
Fix saved card info display error

### DIFF
--- a/chameleonultragui/lib/gui/page/saved_cards.dart
+++ b/chameleonultragui/lib/gui/page/saved_cards.dart
@@ -374,9 +374,9 @@ class SavedCardsPageState extends State<SavedCardsPage> {
                                       Text(
                                           "${localizations.tag_type}: ${chameleonTagToString(tag.tag)}"),
                                       Text(
-                                          "${localizations.sak}: ${tag.sak == 0 ? localizations.unavailable : tag.sak}"),
+                                          "${localizations.sak}: ${tag.sak == 0 ? localizations.unavailable : bytesToHex(u8ToBytes(tag.sak))}"),
                                       Text(
-                                          "${localizations.atqa}: ${tag.atqa.asMap().containsKey(0) ? tag.atqa[0] : ""} ${tag.atqa.asMap().containsKey(1) ? tag.atqa[1] : localizations.unavailable}"),
+                                          "${localizations.atqa}: ${tag.atqa.asMap().containsKey(0) ? bytesToHex(u8ToBytes(tag.atqa[0])) : ""} ${tag.atqa.asMap().containsKey(1) ? bytesToHex(u8ToBytes(tag.atqa[1])) : localizations.unavailable}"),
                                     ],
                                   ),
                                   actions: [

--- a/chameleonultragui/lib/helpers/general.dart
+++ b/chameleonultragui/lib/helpers/general.dart
@@ -39,6 +39,11 @@ int bytesToU64(Uint8List byteArray) {
   return byteArray.buffer.asByteData().getUint64(0, Endian.big);
 }
 
+Uint8List u8ToBytes(int u8) {
+  final ByteData byteData = ByteData(1)..setUint8(0, u8);
+  return byteData.buffer.asUint8List();
+}
+
 Uint8List u64ToBytes(int u64) {
   final ByteData byteData = ByteData(8)..setUint64(0, u64, Endian.big);
   return byteData.buffer.asUint8List();


### PR DESCRIPTION
The display data directly from CardSave object, but the sak is saved as int from byte.
Atqa is saved as bytes, but it was got byte as int one by one.

![pic0](https://github.com/GameTec-live/ChameleonUltraGUI/assets/20784591/0cc07484-3d5a-435b-9c96-c0c217f7b07f)
![pic1](https://github.com/GameTec-live/ChameleonUltraGUI/assets/20784591/b1ba2c5c-8f5c-4ce5-9497-44962cf8b7fc)
