### PR TITLE
Fix iOS status bar icon colors

### DIFF
--- a/chameleonultragui/ios/Runner/Info.plist
+++ b/chameleonultragui/ios/Runner/Info.plist
@@ -58,6 +58,8 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>


### PR DESCRIPTION
UIUserInterfaceStyle has been set to Light because the launch splash always has a white background.
After splashscreen the statusbar icon colors gets correctly set by AppBarTheme.brightness.

I don't have an iOS toolchain at the moment, so testing is welcome.