### PR TITLE
View slot info and editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Download the Linux build
 - [Debian-based (.deb)](https://nightly.link/GameTec-live/ChameleonUltraGUI/workflows/build-app/main/linux-debian.zip). Short link: https://chameleonultragui.dev/linux-debian
 - [Arch-based](https://aur.archlinux.org/packages/chameleonultragui) / [or -git](https://aur.archlinux.org/packages/chameleonultragui-git). Short link: https://chameleonultragui.dev/linux-arch
 - [Other](https://nightly.link/GameTec-live/ChameleonUltraGUI/workflows/build-app/main/linux.zip). Short link: https://chameleonultragui.dev/linux
+- [Other (legacy, built on Ubuntu 20.04 LTS)](https://nightly.link/GameTec-live/ChameleonUltraGUI/workflows/build-app/main/linux-legacy.zip)
 
 #### macOS / iOS / iPadOS
 
@@ -46,6 +47,7 @@ Note: Under some Linux systems, especially ones running KDE desktop environments
 Key:
 - apk: Android APK, download and install either via ADB or your app/file manager of choice
 - linux: zip file containing the linux build, either run the binary manually or install using cmake
+- linux-legacy: same as `linux`, but built on Ubuntu 20.04 LTS. Suited for users on old glibc
 - linux-debian: Debain Auto Packaging, Download and install with either apt, apt-get or dpkg.
 - windows: zip file containing windows build, run the binary manually
 - windows-installer: NSIS based Windows Installer, Installs the Windows build and creates Shortcuts

--- a/chameleonultragui/lib/bridge/chameleon.dart
+++ b/chameleonultragui/lib/bridge/chameleon.dart
@@ -268,29 +268,29 @@ class FirmwareVersion {
 }
 
 class SlotTypes {
-  TagType hfSlot;
-  TagType lfSlot;
+  TagType hf;
+  TagType lf;
 
   bool match({TagType type = TagType.unknown}) {
-    return hfSlot == type || lfSlot == type;
+    return hf == type || lf == type;
   }
 
   bool notMatch({TagType type = TagType.unknown}) {
-    return hfSlot != type || lfSlot != type;
+    return hf != type || lf != type;
   }
 
-  SlotTypes({this.hfSlot = TagType.unknown, this.lfSlot = TagType.unknown});
+  SlotTypes({this.hf = TagType.unknown, this.lf = TagType.unknown});
 }
 
 class EnabledSlotInfo {
-  bool hfSlot;
-  bool lfSlot;
+  bool hf;
+  bool lf;
 
   bool any() {
-    return hfSlot || lfSlot;
+    return hf || lf;
   }
 
-  EnabledSlotInfo({this.hfSlot = false, this.lfSlot = false});
+  EnabledSlotInfo({this.hf = false, this.lf = false});
 }
 
 class BatteryCharge {
@@ -904,9 +904,9 @@ class ChameleonCommunicator {
     var index = 0;
     for (var slot = 0; slot < 8; slot++) {
       tags.add(SlotTypes(
-        hfSlot: numberToChameleonTag(
+        hf: numberToChameleonTag(
             bytesToU16(resp!.data.sublist(index, index + 2))),
-        lfSlot: numberToChameleonTag(
+        lf: numberToChameleonTag(
             bytesToU16(resp.data.sublist(index + 2, index + 4))),
       ));
 
@@ -996,8 +996,7 @@ class ChameleonCommunicator {
     List<EnabledSlotInfo> slots = [];
     for (var slot = 0; slot < 8; slot++) {
       slots.add(EnabledSlotInfo(
-          hfSlot: resp.data[slot * 2] != 0,
-          lfSlot: resp.data[slot * 2 + 1] != 0));
+          hf: resp.data[slot * 2] != 0, lf: resp.data[slot * 2 + 1] != 0));
     }
     return slots;
   }

--- a/chameleonultragui/lib/bridge/chameleon.dart
+++ b/chameleonultragui/lib/bridge/chameleon.dart
@@ -260,6 +260,80 @@ class DetectionResult {
       required this.ar});
 }
 
+class FirmwareVersion {
+  bool legacyProtocol;
+  int version;
+
+  FirmwareVersion({required this.legacyProtocol, required this.version});
+}
+
+class SlotTypes {
+  TagType hfSlot;
+  TagType lfSlot;
+
+  bool match({TagType type = TagType.unknown}) {
+    return hfSlot == type || lfSlot == type;
+  }
+
+  bool notMatch({TagType type = TagType.unknown}) {
+    return hfSlot != type || lfSlot != type;
+  }
+
+  SlotTypes({this.hfSlot = TagType.unknown, this.lfSlot = TagType.unknown});
+}
+
+class EnabledSlotInfo {
+  bool hfSlot;
+  bool lfSlot;
+
+  bool any() {
+    return hfSlot || lfSlot;
+  }
+
+  EnabledSlotInfo({this.hfSlot = false, this.lfSlot = false});
+}
+
+class BatteryCharge {
+  int voltage;
+  int percent;
+
+  BatteryCharge({required this.voltage, required this.percent});
+}
+
+class EmulatorSettings {
+  bool isDetectionEnabled;
+  bool isGen1a;
+  bool isGen2;
+  bool isAntiColl;
+  MifareClassicWriteMode writeMode;
+
+  EmulatorSettings(
+      {required this.isDetectionEnabled,
+      required this.isGen1a,
+      required this.isGen2,
+      required this.isAntiColl,
+      required this.writeMode});
+}
+
+class DeviceSettings {
+  AnimationSetting animation;
+  ButtonConfig aPress;
+  ButtonConfig bPress;
+  ButtonConfig aLongPress;
+  ButtonConfig bLongPress;
+  bool pairingEnabled;
+  String key;
+
+  DeviceSettings(
+      {this.animation = AnimationSetting.none,
+      this.aPress = ButtonConfig.disable,
+      this.bPress = ButtonConfig.disable,
+      this.aLongPress = ButtonConfig.disable,
+      this.bLongPress = ButtonConfig.disable,
+      this.pairingEnabled = false,
+      this.key = ""});
+}
+
 // Some ChatGPT magic
 // Nobody knows how it works
 
@@ -318,6 +392,8 @@ class ChameleonCommunicator {
   }
 
   Future<void> onSerialMessage(List<int> message) async {
+    log.t("Received: ${bytesToHex(Uint8List.fromList(message))}");
+
     for (var byte in message) {
       dataBuffer.add(byte);
 
@@ -392,7 +468,9 @@ class ChameleonCommunicator {
 
     commandQueue.add(cmd.value);
 
-    log.d("Sending: ${bytesToHex(dataFrame)}");
+    log.t("Sending: ${bytesToHex(dataFrame)}");
+    log.d(
+        "Sending message: command = ${cmd.value}, data = ${bytesToHex(data ?? Uint8List(0))}");
 
     if (skipReceive) {
       try {
@@ -435,15 +513,16 @@ class ChameleonCommunicator {
     return bytes.buffer.asByteData().getInt16(0, Endian.big);
   }
 
-  Future<(bool, int)> getFirmwareVersion() async {
+  Future<FirmwareVersion> getFirmwareVersion() async {
     var resp = await sendCmd(ChameleonCommand.getAppVersion);
     if (resp!.data.length != 2) throw ("Invalid data length");
 
     // Check for legacy protocol
     if (resp.data[0] == 0 && resp.data[1] == 1) {
-      return (true, 256);
+      return FirmwareVersion(legacyProtocol: true, version: 256);
     } else {
-      return (false, bytesToU16(resp.data));
+      return FirmwareVersion(
+          legacyProtocol: false, version: bytesToU16(resp.data));
     }
   }
 
@@ -819,14 +898,15 @@ class ChameleonCommunicator {
     return (await sendCmd(ChameleonCommand.getActiveSlot))!.data[0];
   }
 
-  Future<List<(TagType, TagType)>> getUsedSlots() async {
-    List<(TagType, TagType)> tags = [];
+  Future<List<SlotTypes>> getSlotTagTypes() async {
+    List<SlotTypes> tags = [];
     var resp = await sendCmd(ChameleonCommand.getSlotInfo);
     var index = 0;
     for (var slot = 0; slot < 8; slot++) {
-      tags.add((
-        numberToChameleonTag(bytesToU16(resp!.data.sublist(index, index + 2))),
-        numberToChameleonTag(
+      tags.add(SlotTypes(
+        hfSlot: numberToChameleonTag(
+            bytesToU16(resp!.data.sublist(index, index + 2))),
+        lfSlot: numberToChameleonTag(
             bytesToU16(resp.data.sublist(index + 2, index + 4))),
       ));
 
@@ -835,11 +915,11 @@ class ChameleonCommunicator {
     return tags;
   }
 
-  Future<(bool, bool, bool, bool, MifareClassicWriteMode)>
-      getMf1EmulatorConfig() async {
+  Future<EmulatorSettings> getMf1EmulatorSettings() async {
     var resp = await sendCmd(ChameleonCommand.mf1GetEmulatorConfig);
     if (resp!.data.length != 5) throw ("Invalid data length");
     MifareClassicWriteMode mode = MifareClassicWriteMode.normal;
+
     if (resp.data[4] == 1) {
       mode = MifareClassicWriteMode.denied;
     } else if (resp.data[4] == 2) {
@@ -847,13 +927,15 @@ class ChameleonCommunicator {
     } else if (resp.data[4] == 3 || resp.data[4] == 4) {
       mode = MifareClassicWriteMode.shadow;
     }
-    return (
-      resp.data[0] == 1, // is detection enabled
-      resp.data[1] == 1, // is gen1a mode enabled
-      resp.data[2] == 1, // is gen2 mode enabled
-      resp.data[3] == 1, // use anti collision data from block 0 mode enabled
-      mode // write mode
-    );
+
+    return EmulatorSettings(
+        isDetectionEnabled: resp.data[0] == 1, // is detection enabled
+        isGen1a: resp.data[1] == 1, // is gen1a mode enabled
+        isGen2: resp.data[2] == 1, // is gen2 mode enabled
+        isAntiColl: resp.data[3] ==
+            1, // use anti collision data from block 0 mode enabled
+        writeMode: mode // write mode
+        );
   }
 
   Future<bool> isMf1Gen1aMode() async {
@@ -908,20 +990,23 @@ class ChameleonCommunicator {
         data: Uint8List.fromList([mode.value]));
   }
 
-  Future<List<(bool, bool)>> getEnabledSlots() async {
+  Future<List<EnabledSlotInfo>> getEnabledSlots() async {
     var resp = await sendCmd(ChameleonCommand.getEnabledSlots);
     if (resp!.data.length != 16) throw ("Invalid data length");
-    List<(bool, bool)> slots = [];
+    List<EnabledSlotInfo> slots = [];
     for (var slot = 0; slot < 8; slot++) {
-      slots.add((resp.data[slot * 2] != 0, resp.data[slot * 2 + 1] != 0));
+      slots.add(EnabledSlotInfo(
+          hfSlot: resp.data[slot * 2] != 0,
+          lfSlot: resp.data[slot * 2 + 1] != 0));
     }
     return slots;
   }
 
-  Future<(int, int)> getBatteryCharge() async {
+  Future<BatteryCharge> getBatteryCharge() async {
     var resp = await sendCmd(ChameleonCommand.getBatteryCharge);
     if (resp!.data.length != 3) throw ("Invalid data length");
-    return (_toInt16BE(resp.data.sublist(0, 2)), resp.data[2]);
+    return BatteryCharge(
+        voltage: _toInt16BE(resp.data.sublist(0, 2)), percent: resp.data[2]);
   }
 
   Future<ButtonConfig> getButtonConfig(ButtonType type) async {
@@ -1020,16 +1105,7 @@ class ChameleonCommunicator {
     return (await sendCmd(ChameleonCommand.getEM410XemulatorID))!.data;
   }
 
-  Future<
-      (
-        AnimationSetting,
-        ButtonConfig,
-        ButtonConfig,
-        ButtonConfig,
-        ButtonConfig,
-        bool,
-        String
-      )> getDeviceSettings() async {
+  Future<DeviceSettings> getDeviceSettings() async {
     var resp = (await sendCmd(ChameleonCommand.getDeviceSettings))!.data;
     if (resp[0] != 5) {
       throw ("Invalid settings version");
@@ -1041,15 +1117,14 @@ class ChameleonCommunicator {
         aLongPress = getButtonConfigType(resp[4]),
         bLongPress = getButtonConfigType(resp[5]);
 
-    return (
-      animationMode,
-      aPress,
-      bPress,
-      aLongPress,
-      bLongPress,
-      resp[6] == 1,
-      utf8.decode(resp.sublist(7, 13), allowMalformed: true)
-    );
+    return DeviceSettings(
+        animation: animationMode,
+        aPress: aPress,
+        bPress: bPress,
+        aLongPress: aLongPress,
+        bLongPress: bLongPress,
+        pairingEnabled: resp[6] == 1,
+        key: utf8.decode(resp.sublist(7, 13), allowMalformed: true));
   }
 
   Future<List<int>> getDeviceCapabilities() async {

--- a/chameleonultragui/lib/connector/serial_native.dart
+++ b/chameleonultragui/lib/connector/serial_native.dart
@@ -35,14 +35,15 @@ class NativeSerial extends AbstractSerial {
     connectionType = ConnectionType.none;
     isOpen = false;
     messageCallback = null;
+    connected = false;
+    messageCallback = null;
     if (port != null) {
-      port?.close();
       reader?.close();
+      port?.close();
       reader = null;
-      connected = false;
+      port = null;
       return true;
     }
-    connected = false; // For debug button
     return false;
   }
 

--- a/chameleonultragui/lib/gui/component/slot_changer.dart
+++ b/chameleonultragui/lib/gui/component/slot_changer.dart
@@ -23,10 +23,10 @@ class SlotChangerState extends State<SlotChanger> {
 
   Future<List<Icon>> getFutureData() async {
     var appState = context.read<ChameleonGUIState>();
-    List<(TagType, TagType)> usedSlots;
+    List<SlotTypes> usedSlots;
 
     try {
-      usedSlots = await appState.communicator!.getUsedSlots();
+      usedSlots = await appState.communicator!.getSlotTagTypes();
     } catch (_) {
       usedSlots = [];
     }
@@ -34,7 +34,7 @@ class SlotChangerState extends State<SlotChanger> {
     return await getSlotIcons(usedSlots);
   }
 
-  Future<List<Icon>> getSlotIcons(List<(TagType, TagType)> usedSlots) async {
+  Future<List<Icon>> getSlotIcons(List<SlotTypes> usedSlots) async {
     var appState = context.read<ChameleonGUIState>();
     List<Icon> icons = [];
 
@@ -48,14 +48,13 @@ class SlotChangerState extends State<SlotChanger> {
       return [const Icon(Icons.warning)];
     }
 
-    for (int i = 1; i < 9; i++) {
-      if (i == selectedSlot) {
+    for (int i = 0; i < 8; i++) {
+      if (i == selectedSlot - 1) {
         icons.add(const Icon(
           Icons.circle_outlined,
           color: Colors.red,
         ));
-      } else if (usedSlots[i - 1].$1 != TagType.unknown ||
-          usedSlots[i - 1].$2 != TagType.unknown) {
+      } else if (usedSlots[i].notMatch()) {
         icons.add(const Icon(Icons.circle));
       } else {
         icons.add(const Icon(Icons.circle_outlined));

--- a/chameleonultragui/lib/gui/menu/card_view.dart
+++ b/chameleonultragui/lib/gui/menu/card_view.dart
@@ -1,3 +1,4 @@
+import 'package:chameleonultragui/bridge/chameleon.dart';
 import 'package:chameleonultragui/gui/menu/card_edit.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/general.dart';
 import 'package:flutter/material.dart';
@@ -57,37 +58,42 @@ class CardViewMenuState extends State<CardViewMenu> {
               ),
             ],
           ),
-          Row(
-            children: [
-              Text(
-                  "${localizations.sak}: ${widget.tagSave.sak == 0 ? localizations.unavailable : bytesToHex(u8ToBytes(widget.tagSave.sak))}"),
-              IconButton(
-                onPressed: () async {
-                  ClipboardData data = ClipboardData(
-                      text: widget.tagSave.sak == 0
-                          ? localizations.unavailable
-                          : bytesToHex(u8ToBytes(widget.tagSave.sak)));
-                  await Clipboard.setData(data);
-                },
-                icon: const Icon(Icons.copy),
-              ),
-            ],
-          ),
-          Row(
-            children: [
-              Text(
-                  "${localizations.atqa}: ${widget.tagSave.atqa.asMap().containsKey(0) ? bytesToHex(u8ToBytes(widget.tagSave.atqa[0])) : ""} ${widget.tagSave.atqa.asMap().containsKey(1) ? bytesToHex(u8ToBytes(widget.tagSave.atqa[1])) : localizations.unavailable}"),
-              IconButton(
-                onPressed: () async {
-                  ClipboardData data = ClipboardData(
-                      text:
-                          "${widget.tagSave.atqa.asMap().containsKey(0) ? bytesToHex(u8ToBytes(widget.tagSave.atqa[0])) : ""} ${widget.tagSave.atqa.asMap().containsKey(1) ? bytesToHex(u8ToBytes(widget.tagSave.atqa[1])) : localizations.unavailable}");
-                  await Clipboard.setData(data);
-                },
-                icon: const Icon(Icons.copy),
-              ),
-            ],
-          ),
+          ...(chameleonTagToFrequency(widget.tagSave.tag) == TagFrequency.hf)
+              ? [
+                  Row(
+                    children: [
+                      Text(
+                          "${localizations.sak}: ${widget.tagSave.sak == 0 ? localizations.unavailable : bytesToHex(u8ToBytes(widget.tagSave.sak))}"),
+                      IconButton(
+                        onPressed: () async {
+                          ClipboardData data = ClipboardData(
+                              text: widget.tagSave.sak == 0
+                                  ? localizations.unavailable
+                                  : bytesToHex(u8ToBytes(widget.tagSave.sak)));
+                          await Clipboard.setData(data);
+                        },
+                        icon: const Icon(Icons.copy),
+                      ),
+                    ],
+                  ),
+                  Row(
+                    children: [
+                      Text(
+                          "${localizations.atqa}: ${widget.tagSave.atqa.isNotEmpty ? bytesToHexSpace(widget.tagSave.atqa) : localizations.unavailable}"),
+                      IconButton(
+                        onPressed: () async {
+                          ClipboardData data = ClipboardData(
+                              text: widget.tagSave.atqa.isNotEmpty
+                                  ? bytesToHex(widget.tagSave.atqa)
+                                  : localizations.unavailable);
+                          await Clipboard.setData(data);
+                        },
+                        icon: const Icon(Icons.copy),
+                      ),
+                    ],
+                  )
+                ]
+              : [],
         ],
       ),
       actions: [

--- a/chameleonultragui/lib/gui/menu/chameleon_settings.dart
+++ b/chameleonultragui/lib/gui/menu/chameleon_settings.dart
@@ -18,8 +18,6 @@ class ChameleonSettings extends StatefulWidget {
 }
 
 class ChameleonSettingsState extends State<ChameleonSettings> {
-  late AnimationSetting animationMode;
-
   @override
   void initState() {
     super.initState();
@@ -145,7 +143,7 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                           localizations.mini,
                           localizations.none
                         ],
-                        selectedValue: animationMode.value,
+                        selectedValue: settings.animation.value,
                         onChange: (int index) async {
                           var animation = AnimationSetting.full;
                           if (index == 1) {

--- a/chameleonultragui/lib/gui/menu/chameleon_settings.dart
+++ b/chameleonultragui/lib/gui/menu/chameleon_settings.dart
@@ -25,29 +25,12 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
     super.initState();
   }
 
-  Future<
-      (
-        AnimationSetting,
-        ButtonConfig,
-        ButtonConfig,
-        ButtonConfig,
-        ButtonConfig,
-        bool,
-        String
-      )> getSettingsData() async {
+  Future<DeviceSettings> getSettingsData() async {
     var appState = context.read<ChameleonGUIState>();
     try {
       return await appState.communicator!.getDeviceSettings();
     } catch (_) {
-      return (
-        AnimationSetting.full,
-        ButtonConfig.disable,
-        ButtonConfig.disable,
-        ButtonConfig.disable,
-        ButtonConfig.disable,
-        false,
-        ""
-      );
+      return DeviceSettings();
     }
   }
 
@@ -72,17 +55,9 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                 content: Text(
                     '${localizations.error}: ${snapshot.error.toString()}'));
           } else {
-            var (
-              animationMode,
-              aButtonMode,
-              bButtonMode,
-              aLongButtonMode,
-              bLongButtonMode,
-              pairingEnabled,
-              connectionKey
-            ) = snapshot.data;
+            DeviceSettings settings = snapshot.data;
             TextEditingController bleKeyController =
-                TextEditingController(text: connectionKey);
+                TextEditingController(text: settings.key);
             return AlertDialog(
                 title: Text(localizations.device_settings),
                 content: SingleChildScrollView(
@@ -97,7 +72,7 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                             onPressed: () async {
                               await appState.communicator!.enterDFUMode();
                               appState.connector!.performDisconnect();
-                              Navigator.pop(buildContext, localizations.cancel);
+                              Navigator.pop(buildContext);
                               appState.changesMade();
                             },
                             child: Row(
@@ -111,7 +86,7 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                         fit: BoxFit.scaleDown,
                         child: TextButton(
                             onPressed: () async {
-                              Navigator.pop(buildContext, localizations.cancel);
+                              Navigator.pop(buildContext);
                               var snackBar = SnackBar(
                                 content: Text(localizations.downloading_fw(
                                     chameleonDeviceName(
@@ -151,7 +126,7 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                         fit: BoxFit.scaleDown,
                         child: TextButton(
                             onPressed: () async {
-                              Navigator.pop(buildContext, localizations.cancel);
+                              Navigator.pop(buildContext);
                               await flashFirmwareZip(appState,
                                   scaffoldMessenger: scaffoldMessenger);
                             },
@@ -199,7 +174,7 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                           localizations.clone_uid,
                           localizations.charge
                         ],
-                        selectedValue: aButtonMode.value,
+                        selectedValue: settings.aPress.value,
                         onChange: (int index) async {
                           var mode = ButtonConfig.disable;
                           if (index == 1) {
@@ -230,7 +205,7 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                           localizations.clone_uid,
                           localizations.charge
                         ],
-                        selectedValue: bButtonMode.value,
+                        selectedValue: settings.bPress.value,
                         onChange: (int index) async {
                           var mode = ButtonConfig.disable;
                           if (index == 1) {
@@ -263,7 +238,7 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                           localizations.clone_uid,
                           localizations.charge
                         ],
-                        selectedValue: aLongButtonMode.value,
+                        selectedValue: settings.aLongPress.value,
                         onChange: (int index) async {
                           var mode = ButtonConfig.disable;
                           if (index == 1) {
@@ -294,7 +269,7 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                           localizations.clone_uid,
                           localizations.charge
                         ],
-                        selectedValue: bLongButtonMode.value,
+                        selectedValue: settings.bLongPress.value,
                         onChange: (int index) async {
                           var mode = ButtonConfig.disable;
                           if (index == 1) {
@@ -323,7 +298,7 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                           localizations.enabled,
                           localizations.disabled,
                         ],
-                        selectedValue: pairingEnabled ? 0 : 1,
+                        selectedValue: settings.pairingEnabled ? 0 : 1,
                         onChange: (int index) async {
                           await appState.communicator!
                               .setBLEPairEnabled(index == 0);
@@ -331,7 +306,7 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                           setState(() {});
                           appState.changesMade();
                         }),
-                    ...(pairingEnabled)
+                    ...(settings.pairingEnabled)
                         ? [
                             const SizedBox(height: 10),
                             FittedBox(
@@ -358,16 +333,14 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                                                   await appState.connector!
                                                       .performDisconnect();
                                                 }
-                                                Navigator.pop(context,
-                                                    localizations.cancel);
+                                                Navigator.pop(context);
                                                 appState.changesMade();
                                               },
                                               child: Text(localizations.yes),
                                             ),
                                             TextButton(
-                                              onPressed: () => Navigator.pop(
-                                                  context,
-                                                  localizations.cancel),
+                                              onPressed: () =>
+                                                  Navigator.pop(context),
                                               child: Text(localizations.no),
                                             ),
                                           ],
@@ -422,8 +395,7 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                                                   bleKeyController.text);
                                           await appState.communicator!
                                               .saveSettings();
-                                          Navigator.pop(
-                                              context, localizations.cancel);
+                                          Navigator.pop(context);
                                           appState.changesMade();
                                         }
                                       },
@@ -442,7 +414,7 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                         child: TextButton(
                             onPressed: () async {
                               await appState.communicator!.resetSettings();
-                              Navigator.pop(context, localizations.cancel);
+                              Navigator.pop(context);
                               appState.changesMade();
                             },
                             child: Row(
@@ -457,7 +429,7 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                         child: TextButton(
                             onPressed: () async {
                               // Ask for confirmation
-                              Navigator.pop(context, localizations.cancel);
+                              Navigator.pop(context);
                               showDialog(
                                 context: context,
                                 builder: (BuildContext context) => AlertDialog(
@@ -471,8 +443,7 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                                             .factoryReset();
                                         await appState.connector!
                                             .performDisconnect();
-                                        Navigator.pop(
-                                            context, localizations.cancel);
+                                        Navigator.pop(context);
                                         appState.changesMade();
                                       },
                                       child: Text(localizations.yes),

--- a/chameleonultragui/lib/gui/menu/slot_edit.dart
+++ b/chameleonultragui/lib/gui/menu/slot_edit.dart
@@ -1,0 +1,512 @@
+import 'package:chameleonultragui/bridge/chameleon.dart';
+import 'package:chameleonultragui/gui/component/toggle_buttons.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/general.dart';
+import 'package:chameleonultragui/helpers/ntag/general.dart';
+import 'package:flutter/material.dart';
+import 'package:chameleonultragui/helpers/general.dart';
+import 'package:provider/provider.dart';
+import 'package:chameleonultragui/main.dart';
+
+// Localizations
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class SlotEditMenu extends StatefulWidget {
+  final String name;
+  final bool isEnabled;
+  final TagType slotType;
+  final TagFrequency frequency;
+  final int slot;
+  final dynamic update;
+
+  const SlotEditMenu(
+      {Key? key,
+      required this.name,
+      required this.isEnabled,
+      required this.slotType,
+      required this.frequency,
+      required this.slot,
+      required this.update})
+      : super(key: key);
+
+  @override
+  SlotEditMenuState createState() => SlotEditMenuState();
+}
+
+class SlotEditMenuState extends State<SlotEditMenu> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  TextEditingController nameController = TextEditingController();
+  TextEditingController uidController = TextEditingController();
+  TextEditingController sakController = TextEditingController();
+  TextEditingController atqaController = TextEditingController();
+  TextEditingController atsController = TextEditingController();
+  TagType? selectedType;
+  TagType previousTagType = TagType.unknown;
+  EmulatorSettings? emulatorSettings;
+  int detectionCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    selectedType = widget.slotType;
+    nameController.text = widget.name;
+  }
+
+  Future<void> updateInfo() async {
+    var appState = context.watch<ChameleonGUIState>();
+
+    if (previousTagType == selectedType ||
+        isMifareClassic(previousTagType) && isMifareClassic(selectedType!)) {
+      return;
+    }
+
+    await appState.communicator!.activateSlot(widget.slot);
+
+    if (selectedType == TagType.em410X) {
+      try {
+        uidController.text =
+            bytesToHexSpace(await appState.communicator!.getEM410XEmulatorID());
+      } catch (_) {}
+    } else if (isMifareClassic(selectedType!)) {
+      try {
+        CardData data = await appState.communicator!.mf1GetAntiCollData();
+        uidController.text = bytesToHexSpace(data.uid);
+        sakController.text = bytesToHex(u8ToBytes(data.sak));
+        atqaController.text = bytesToHexSpace(data.atqa);
+        atsController.text = bytesToHexSpace(data.ats);
+
+        emulatorSettings =
+            await appState.communicator!.getMf1EmulatorSettings();
+
+        if (emulatorSettings!.isDetectionEnabled) {
+          detectionCount = await appState.communicator!.getMf1DetectionCount();
+        }
+      } catch (_) {}
+    }
+
+    setState(() {
+      previousTagType = selectedType!;
+    });
+  }
+
+  Future<void> save() async {
+    var appState = Provider.of<ChameleonGUIState>(context, listen: false);
+
+    await appState.communicator!.activateSlot(widget.slot);
+    if (widget.slotType != selectedType) {
+      await appState.communicator!.setSlotType(widget.slot, selectedType!);
+      if (!isMifareClassic(selectedType!) ||
+          !(isMifareClassic(selectedType!) &&
+              isMifareClassic(widget.slotType))) {
+        await appState.communicator!
+            .setDefaultDataToSlot(widget.slot, selectedType!);
+      }
+    }
+
+    if (selectedType == TagType.em410X) {
+      await appState.communicator!
+          .setEM410XEmulatorID(hexToBytesSpace(uidController.text));
+    } else if (isMifareClassic(selectedType!)) {
+      var cardData = CardData(
+          uid: hexToBytesSpace(uidController.text),
+          atqa: hexToBytesSpace(atqaController.text),
+          sak: bytesToU8(hexToBytesSpace(sakController.text)),
+          ats: hexToBytesSpace(atsController.text));
+      await appState.communicator!.setMf1AntiCollision(cardData);
+    }
+
+    await appState.communicator!
+        .setSlotTagName(widget.slot, nameController.text, widget.frequency);
+    await appState.communicator!.saveSlotData();
+
+    widget.update(nameController.text, widget.frequency, selectedType);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var localizations = AppLocalizations.of(context)!;
+    var appState = context.watch<ChameleonGUIState>();
+
+    return AlertDialog(
+      title: Text(localizations.edit_slot_data),
+      content: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          autovalidateMode: AutovalidateMode.onUserInteraction,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: nameController,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return localizations.please_enter_name;
+                  }
+                  if (value.length > 19) {
+                    return localizations.too_long_name;
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 8),
+              DropdownButton<TagType>(
+                value: selectedType,
+                items: [
+                  ...getTagTypeByFrequency(widget.frequency),
+                  TagType.unknown
+                ].map<DropdownMenuItem<TagType>>((TagType type) {
+                  return DropdownMenuItem<TagType>(
+                    value: type,
+                    child: Text(
+                      chameleonTagToString(type),
+                    ),
+                  );
+                }).toList(),
+                onChanged: (TagType? newValue) {
+                  if (newValue != TagType.unknown && !isNTAG(newValue!)) {
+                    setState(() {
+                      selectedType = newValue;
+                    });
+                  }
+                },
+              ),
+              FutureBuilder(
+                  future: updateInfo(),
+                  builder: (BuildContext context, AsyncSnapshot snapshot) {
+                    if (snapshot.connectionState == ConnectionState.waiting) {
+                      return const Column(
+                          children: [CircularProgressIndicator()]);
+                    } else if (snapshot.hasError) {
+                      appState.connector!.performDisconnect();
+                      return Text(
+                          '${localizations.error}: ${snapshot.error.toString()}');
+                    } else {
+                      return Visibility(
+                          visible: selectedType != TagType.unknown,
+                          child: Column(children: [
+                            Column(children: [
+                              const SizedBox(height: 8),
+                              TextFormField(
+                                controller: uidController,
+                                decoration: InputDecoration(
+                                    labelText: localizations.uid,
+                                    hintText: localizations
+                                        .enter_something(localizations.uid)),
+                                validator: (value) {
+                                  if (value == null || value.isEmpty) {
+                                    return localizations.please_enter_something(
+                                        localizations.uid);
+                                  }
+                                  if (!(value.replaceAll(" ", "").length ==
+                                              14 ||
+                                          value.replaceAll(" ", "").length ==
+                                              8) &&
+                                      chameleonTagToFrequency(selectedType ??
+                                              widget.slotType) !=
+                                          TagFrequency.lf) {
+                                    return localizations.must_or(
+                                        4, 7, localizations.uid);
+                                  }
+                                  if (value.replaceAll(" ", "").length != 10 &&
+                                      chameleonTagToFrequency(selectedType ??
+                                              widget.slotType) ==
+                                          TagFrequency.lf) {
+                                    return localizations.must_be(
+                                        5, localizations.uid);
+                                  }
+                                  return null;
+                                },
+                              ),
+                              Visibility(
+                                  visible: chameleonTagToFrequency(
+                                          selectedType ?? widget.slotType) !=
+                                      TagFrequency.lf,
+                                  child: Column(
+                                    children: [
+                                      const SizedBox(height: 20),
+                                      TextFormField(
+                                        controller: sakController,
+                                        decoration: InputDecoration(
+                                            labelText: localizations.sak,
+                                            hintText:
+                                                localizations.enter_something(
+                                                    localizations.sak)),
+                                        validator: (value) {
+                                          if (value == null ||
+                                              value.isEmpty &&
+                                                  chameleonTagToFrequency(
+                                                          selectedType ??
+                                                              widget
+                                                                  .slotType) !=
+                                                      TagFrequency.lf) {
+                                            return localizations
+                                                .please_enter_something(
+                                                    localizations.sak);
+                                          }
+                                          if (value
+                                                      .replaceAll(" ", "")
+                                                      .length !=
+                                                  2 &&
+                                              chameleonTagToFrequency(
+                                                      selectedType ??
+                                                          widget.slotType) !=
+                                                  TagFrequency.lf) {
+                                            return localizations.must_be(
+                                                1, localizations.sak);
+                                          }
+                                          return null;
+                                        },
+                                      ),
+                                      const SizedBox(height: 20),
+                                      TextFormField(
+                                        controller: atqaController,
+                                        decoration: InputDecoration(
+                                            labelText: localizations.atqa,
+                                            hintText:
+                                                localizations.enter_something(
+                                                    localizations.atqa)),
+                                        validator: (value) {
+                                          if (value == null ||
+                                              value.isEmpty &&
+                                                  chameleonTagToFrequency(
+                                                          selectedType ??
+                                                              widget
+                                                                  .slotType) !=
+                                                      TagFrequency.lf) {
+                                            return localizations
+                                                .please_enter_something(
+                                                    localizations.atqa);
+                                          }
+                                          if (value
+                                                      .replaceAll(" ", "")
+                                                      .length !=
+                                                  4 &&
+                                              chameleonTagToFrequency(
+                                                      selectedType ??
+                                                          widget.slotType) !=
+                                                  TagFrequency.lf) {
+                                            return localizations.must_be(
+                                                2, localizations.atqa);
+                                          }
+                                          return null;
+                                        },
+                                      ),
+                                      const SizedBox(height: 20),
+                                      TextFormField(
+                                          controller: atsController,
+                                          decoration: InputDecoration(
+                                              labelText: localizations.ats,
+                                              hintText:
+                                                  localizations.enter_something(
+                                                      localizations.ats)),
+                                          validator: (value) {
+                                            if (value!
+                                                        .replaceAll(" ", "")
+                                                        .length %
+                                                    2 !=
+                                                0) {
+                                              return localizations
+                                                  .must_be_valid_hex;
+                                            }
+                                            return null;
+                                          }),
+                                      if (isMifareClassic(selectedType!) &&
+                                          emulatorSettings != null)
+                                        Column(children: [
+                                          const SizedBox(height: 20),
+                                          Text(
+                                            localizations
+                                                .mifare_classic_emulator_settings,
+                                            textScaleFactor: 1.1,
+                                          ),
+                                          const SizedBox(height: 8),
+                                          Text(localizations.mode_gen1a),
+                                          const SizedBox(height: 8),
+                                          ToggleButtonsWrapper(
+                                              items: [
+                                                localizations.yes,
+                                                localizations.no
+                                              ],
+                                              selectedValue:
+                                                  emulatorSettings!.isGen1a
+                                                      ? 0
+                                                      : 1,
+                                              onChange: (int index) async {
+                                                await appState.communicator!
+                                                    .setMf1Gen1aMode(index == 0
+                                                        ? true
+                                                        : false);
+                                              }),
+                                          const SizedBox(height: 8),
+                                          Text(localizations.mode_gen2),
+                                          const SizedBox(height: 8),
+                                          ToggleButtonsWrapper(
+                                              items: [
+                                                localizations.yes,
+                                                localizations.no
+                                              ],
+                                              selectedValue:
+                                                  emulatorSettings!.isGen2
+                                                      ? 0
+                                                      : 1,
+                                              onChange: (int index) async {
+                                                await appState.communicator!
+                                                    .setMf1Gen2Mode(index == 0
+                                                        ? true
+                                                        : false);
+                                              }),
+                                          const SizedBox(height: 8),
+                                          Text(localizations.use_from_block),
+                                          const SizedBox(height: 8),
+                                          ToggleButtonsWrapper(
+                                              items: [
+                                                localizations.yes,
+                                                localizations.no
+                                              ],
+                                              selectedValue:
+                                                  emulatorSettings!.isAntiColl
+                                                      ? 0
+                                                      : 1,
+                                              onChange: (int index) async {
+                                                await appState.communicator!
+                                                    .setMf1UseFirstBlockColl(
+                                                        index == 0
+                                                            ? true
+                                                            : false);
+                                              }),
+                                          const SizedBox(height: 8),
+                                          Text(localizations
+                                              .collect_nonces('Mfkey32')),
+                                          const SizedBox(height: 8),
+                                          ToggleButtonsWrapper(
+                                              items: [
+                                                localizations.yes,
+                                                localizations.no
+                                              ],
+                                              selectedValue: emulatorSettings!
+                                                      .isDetectionEnabled
+                                                  ? 0
+                                                  : 1,
+                                              onChange: (int index) async {
+                                                await appState.communicator!
+                                                    .setMf1DetectionStatus(
+                                                        index == 0
+                                                            ? true
+                                                            : false);
+                                              }),
+                                          ...(emulatorSettings!
+                                                  .isDetectionEnabled)
+                                              ? [
+                                                  ...(detectionCount == 0)
+                                                      ? [
+                                                          const SizedBox(
+                                                              height: 8),
+                                                          Text(
+                                                              localizations
+                                                                  .present_cham_reader_keys,
+                                                              textScaleFactor:
+                                                                  0.8)
+                                                        ]
+                                                      : [
+                                                          const SizedBox(
+                                                              height: 8),
+                                                          Row(
+                                                              mainAxisAlignment:
+                                                                  MainAxisAlignment
+                                                                      .center,
+                                                              children: [
+                                                                TextButton(
+                                                                    onPressed:
+                                                                        () {
+                                                                      Navigator.pop(
+                                                                          context);
+                                                                      appState.forceMfkey32Page =
+                                                                          true;
+                                                                      appState
+                                                                          .changesMade();
+                                                                    },
+                                                                    child: Row(
+                                                                      children: [
+                                                                        const Icon(
+                                                                            Icons.lock_open),
+                                                                        Text(localizations
+                                                                            .recover_keys),
+                                                                      ],
+                                                                    )),
+                                                              ]),
+                                                        ],
+                                                ]
+                                              : [
+                                                  const SizedBox(height: 8),
+                                                  Text(
+                                                      localizations
+                                                          .ena_coll_recover_keys,
+                                                      textScaleFactor: 0.8)
+                                                ],
+                                          const SizedBox(height: 8),
+                                          Text(localizations.write_mode),
+                                          const SizedBox(height: 8),
+                                          ToggleButtonsWrapper(
+                                              items: [
+                                                localizations.normal,
+                                                localizations.decline,
+                                                localizations.deceive,
+                                                localizations.shadow
+                                              ],
+                                              selectedValue: emulatorSettings!
+                                                  .writeMode.value,
+                                              onChange: (int index) async {
+                                                if (index == 0) {
+                                                  await appState.communicator!
+                                                      .setMf1WriteMode(
+                                                          MifareClassicWriteMode
+                                                              .normal);
+                                                } else if (index == 1) {
+                                                  await appState.communicator!
+                                                      .setMf1WriteMode(
+                                                          MifareClassicWriteMode
+                                                              .denied);
+                                                } else if (index == 2) {
+                                                  await appState.communicator!
+                                                      .setMf1WriteMode(
+                                                          MifareClassicWriteMode
+                                                              .deceive);
+                                                } else if (index == 3) {
+                                                  await appState.communicator!
+                                                      .setMf1WriteMode(
+                                                          MifareClassicWriteMode
+                                                              .shadow);
+                                                }
+                                              }),
+                                        ]),
+                                    ],
+                                  )),
+                            ])
+                          ]));
+                    }
+                  })
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(localizations.cancel),
+        ),
+        TextButton(
+          onPressed: () async {
+            if (!_formKey.currentState!.validate()) {
+              return;
+            }
+
+            await save();
+
+            if (context.mounted) {
+              Navigator.pop(context);
+            }
+          },
+          child: Text(localizations.save),
+        ),
+      ],
+    );
+  }
+}

--- a/chameleonultragui/lib/gui/menu/slot_export.dart
+++ b/chameleonultragui/lib/gui/menu/slot_export.dart
@@ -44,15 +44,15 @@ class SlotExportMenuState extends State<SlotExportMenu> {
       return CardSave(
         uid:
             bytesToHexSpace(await appState.communicator!.getEM410XEmulatorID()),
-        name: widget.names.lfName,
-        tag: widget.slotTypes.lfSlot,
+        name: widget.names.lf,
+        tag: widget.slotTypes.lf,
       );
     } else {
       CardData data = await appState.communicator!.mf1GetAntiCollData();
       List<Uint8List> binData = [];
 
       int blockCount = mfClassicGetBlockCount(
-          chameleonTagTypeGetMfClassicType(widget.slotTypes.hfSlot));
+          chameleonTagTypeGetMfClassicType(widget.slotTypes.hf));
       for (int block = 0; block < blockCount; block += 16) {
         Uint8List blockData =
             await appState.communicator!.mf1GetEmulatorBlock(block, block + 16);
@@ -61,11 +61,11 @@ class SlotExportMenuState extends State<SlotExportMenu> {
 
       return CardSave(
         uid: bytesToHexSpace(data.uid),
-        name: widget.names.lfName,
+        name: widget.names.lf,
         sak: data.sak,
         atqa: data.atqa,
         ats: data.ats,
-        tag: widget.slotTypes.hfSlot,
+        tag: widget.slotTypes.hf,
         data: binData,
       );
     }
@@ -107,11 +107,11 @@ class SlotExportMenuState extends State<SlotExportMenu> {
     var appState = context.watch<ChameleonGUIState>();
 
     List<String> buttons = [];
-    if (widget.slotTypes.hfSlot != TagType.unknown) {
+    if (widget.slotTypes.hf != TagType.unknown) {
       buttons.add(localizations.hf);
     }
 
-    if (widget.slotTypes.lfSlot != TagType.unknown) {
+    if (widget.slotTypes.lf != TagType.unknown) {
       buttons.add(localizations.lf);
     }
 

--- a/chameleonultragui/lib/gui/menu/slot_settings.dart
+++ b/chameleonultragui/lib/gui/menu/slot_settings.dart
@@ -9,10 +9,10 @@ import 'package:chameleonultragui/main.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class SlotNames {
-  String hfName;
-  String lfName;
+  String hf;
+  String lf;
 
-  SlotNames({this.hfName = "", this.lfName = ""});
+  SlotNames({this.hf = "", this.lf = ""});
 }
 
 class SlotSettings extends StatefulWidget {
@@ -37,7 +37,7 @@ class SlotSettingsState extends State<SlotSettings> {
   }
 
   Future<void> fetchInfo() async {
-    if (names.hfName.isNotEmpty) {
+    if (names.hf.isNotEmpty) {
       return;
     }
 
@@ -49,9 +49,9 @@ class SlotSettingsState extends State<SlotSettings> {
               .getSlotTagName(widget.slot, TagFrequency.hf))
           .trim();
       if (name.isEmpty) {
-        names.hfName = localizations.empty;
+        names.hf = localizations.empty;
       } else {
-        names.hfName = name;
+        names.hf = name;
       }
     } catch (_) {}
 
@@ -60,9 +60,9 @@ class SlotSettingsState extends State<SlotSettings> {
               .getSlotTagName(widget.slot, TagFrequency.lf))
           .trim();
       if (name.isEmpty) {
-        names.lfName = localizations.empty;
+        names.lf = localizations.empty;
       } else {
-        names.lfName = name;
+        names.lf = name;
       }
     } catch (_) {}
 
@@ -74,11 +74,11 @@ class SlotSettingsState extends State<SlotSettings> {
 
   void updateSlot(String name, TagFrequency frequency, TagType type) {
     if (frequency == TagFrequency.hf) {
-      names.hfName = name;
-      slotTypes.hfSlot = type;
+      names.hf = name;
+      slotTypes.hf = type;
     } else if (frequency == TagFrequency.lf) {
-      names.lfName = name;
-      slotTypes.lfSlot = type;
+      names.lf = name;
+      slotTypes.lf = type;
     }
 
     widget.refresh(widget.slot);
@@ -95,7 +95,7 @@ class SlotSettingsState extends State<SlotSettings> {
         future: fetchInfo(),
         builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting &&
-              names.hfName.isNotEmpty) {
+              names.hf.isNotEmpty) {
             return AlertDialog(
                 title: Text(localizations.slot_settings),
                 content: const SingleChildScrollView(
@@ -142,14 +142,14 @@ class SlotSettingsState extends State<SlotSettings> {
                           showDialog<String>(
                               context: context,
                               builder: (BuildContext context) => SlotEditMenu(
-                                  name: names.hfName,
-                                  isEnabled: enabledSlot.hfSlot,
-                                  slotType: slotTypes.hfSlot,
+                                  name: names.hf,
+                                  isEnabled: enabledSlot.hf,
+                                  slotType: slotTypes.hf,
                                   frequency: TagFrequency.hf,
                                   slot: widget.slot,
                                   update: updateSlot));
                         },
-                        child: Text(names.hfName),
+                        child: Text(names.hf),
                       )),
                       const SizedBox(width: 8),
                       IconButton(
@@ -163,8 +163,8 @@ class SlotSettingsState extends State<SlotSettings> {
                           await appState.communicator!.saveSlotData();
 
                           setState(() {
-                            names.hfName = localizations.empty;
-                            slotTypes.hfSlot = TagType.unknown;
+                            names.hf = localizations.empty;
+                            slotTypes.hf = TagType.unknown;
                           });
 
                           widget.refresh(widget.slot);
@@ -173,17 +173,17 @@ class SlotSettingsState extends State<SlotSettings> {
                       ),
                       IconButton(
                         onPressed: () async {
-                          await appState.communicator!.enableSlot(widget.slot,
-                              TagFrequency.hf, !enabledSlot.hfSlot);
+                          await appState.communicator!.enableSlot(
+                              widget.slot, TagFrequency.hf, !enabledSlot.hf);
                           await appState.communicator!.saveSlotData();
 
                           setState(() {
-                            enabledSlot.hfSlot = !enabledSlot.hfSlot;
+                            enabledSlot.hf = !enabledSlot.hf;
                           });
 
                           widget.refresh(widget.slot);
                         },
-                        icon: Icon(enabledSlot.hfSlot
+                        icon: Icon(enabledSlot.hf
                             ? Icons.toggle_on
                             : Icons.toggle_off),
                       ),
@@ -200,14 +200,14 @@ class SlotSettingsState extends State<SlotSettings> {
                           showDialog<String>(
                               context: context,
                               builder: (BuildContext context) => SlotEditMenu(
-                                  name: names.lfName,
-                                  isEnabled: enabledSlot.lfSlot,
-                                  slotType: slotTypes.lfSlot,
+                                  name: names.lf,
+                                  isEnabled: enabledSlot.lf,
+                                  slotType: slotTypes.lf,
                                   frequency: TagFrequency.lf,
                                   slot: widget.slot,
                                   update: updateSlot));
                         },
-                        child: Text(names.lfName),
+                        child: Text(names.lf),
                       )),
                       const SizedBox(width: 8),
                       IconButton(
@@ -221,8 +221,8 @@ class SlotSettingsState extends State<SlotSettings> {
                           await appState.communicator!.saveSlotData();
 
                           setState(() {
-                            names.lfName = localizations.empty;
-                            slotTypes.lfSlot = TagType.unknown;
+                            names.lf = localizations.empty;
+                            slotTypes.lf = TagType.unknown;
                           });
 
                           widget.refresh(widget.slot);
@@ -231,17 +231,17 @@ class SlotSettingsState extends State<SlotSettings> {
                       ),
                       IconButton(
                         onPressed: () async {
-                          await appState.communicator!.enableSlot(widget.slot,
-                              TagFrequency.lf, !enabledSlot.lfSlot);
+                          await appState.communicator!.enableSlot(
+                              widget.slot, TagFrequency.lf, !enabledSlot.lf);
                           await appState.communicator!.saveSlotData();
 
                           setState(() {
-                            enabledSlot.lfSlot = !enabledSlot.lfSlot;
+                            enabledSlot.lf = !enabledSlot.lf;
                           });
 
                           widget.refresh(widget.slot);
                         },
-                        icon: Icon(enabledSlot.lfSlot
+                        icon: Icon(enabledSlot.lf
                             ? Icons.toggle_on
                             : Icons.toggle_off),
                       ),

--- a/chameleonultragui/lib/gui/menu/slot_settings.dart
+++ b/chameleonultragui/lib/gui/menu/slot_settings.dart
@@ -1,5 +1,5 @@
 import 'package:chameleonultragui/bridge/chameleon.dart';
-import 'package:chameleonultragui/gui/component/toggle_buttons.dart';
+import 'package:chameleonultragui/gui/menu/slot_edit.dart';
 import 'package:chameleonultragui/gui/menu/slot_export.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -7,6 +7,13 @@ import 'package:chameleonultragui/main.dart';
 
 // Localizations
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class SlotNames {
+  String hfName;
+  String lfName;
+
+  SlotNames({this.hfName = "", this.lfName = ""});
+}
 
 class SlotSettings extends StatefulWidget {
   final int slot;
@@ -19,17 +26,9 @@ class SlotSettings extends StatefulWidget {
 }
 
 class SlotSettingsState extends State<SlotSettings> {
-  bool isRun = false;
-  List<(bool, bool)> enabledSlots = [];
-  List<(TagType, TagType)> usedSlots = [];
-  late bool isDetection;
-  late int detectionCount;
-  late bool isGen1a;
-  late bool isGen2;
-  late bool isAntiColl;
-  late MifareClassicWriteMode writeMode;
-  String hfName = '';
-  String lfName = '';
+  EnabledSlotInfo enabledSlot = EnabledSlotInfo();
+  SlotTypes slotTypes = SlotTypes();
+  SlotNames names = SlotNames();
   TagFrequency exportFrequency = TagFrequency.hf;
 
   @override
@@ -38,54 +37,53 @@ class SlotSettingsState extends State<SlotSettings> {
   }
 
   Future<void> fetchInfo() async {
+    if (names.hfName.isNotEmpty) {
+      return;
+    }
+
     var appState = context.read<ChameleonGUIState>();
     var localizations = AppLocalizations.of(context)!;
-    if (hfName.isEmpty) {
-      try {
-        hfName = (await appState.communicator!
-                .getSlotTagName(widget.slot, TagFrequency.hf))
-            .trim();
-      } catch (_) {}
 
-      if (hfName.isEmpty) {
-        hfName = localizations.empty;
-      }
-
-      setState(() {});
-    }
-
-    if (lfName.isEmpty) {
-      try {
-        lfName = (await appState.communicator!
-                .getSlotTagName(widget.slot, TagFrequency.lf))
-            .trim();
-      } catch (_) {}
-
-      if (lfName.isEmpty) {
-        lfName = localizations.empty;
-      }
-
-      setState(() {});
-    }
-
-    if (!isRun) {
-      enabledSlots = await appState.communicator!.getEnabledSlots();
-      usedSlots = await appState.communicator!.getUsedSlots();
-      await appState.communicator!.activateSlot(widget.slot);
-      var data = (await appState.communicator!.getMf1EmulatorConfig());
-      isDetection = data.$1;
-      if (isDetection) {
-        detectionCount = await appState.communicator!.getMf1DetectionCount();
+    try {
+      String name = (await appState.communicator!
+              .getSlotTagName(widget.slot, TagFrequency.hf))
+          .trim();
+      if (name.isEmpty) {
+        names.hfName = localizations.empty;
       } else {
-        detectionCount = 0;
+        names.hfName = name;
       }
-      isGen1a = data.$2;
-      isGen2 = data.$3;
-      isAntiColl = data.$4;
-      writeMode = data.$5;
-      isRun = true;
-      setState(() {});
+    } catch (_) {}
+
+    try {
+      String name = (await appState.communicator!
+              .getSlotTagName(widget.slot, TagFrequency.lf))
+          .trim();
+      if (name.isEmpty) {
+        names.lfName = localizations.empty;
+      } else {
+        names.lfName = name;
+      }
+    } catch (_) {}
+
+    enabledSlot = (await appState.communicator!.getEnabledSlots())[widget.slot];
+    slotTypes = (await appState.communicator!.getSlotTagTypes())[widget.slot];
+
+    setState(() {});
+  }
+
+  void updateSlot(String name, TagFrequency frequency, TagType type) {
+    if (frequency == TagFrequency.hf) {
+      names.hfName = name;
+      slotTypes.hfSlot = type;
+    } else if (frequency == TagFrequency.lf) {
+      names.lfName = name;
+      slotTypes.lfSlot = type;
     }
+
+    widget.refresh(widget.slot);
+
+    setState(() {});
   }
 
   @override
@@ -96,7 +94,8 @@ class SlotSettingsState extends State<SlotSettings> {
     return FutureBuilder(
         future: fetchInfo(),
         builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting && !isRun) {
+          if (snapshot.connectionState == ConnectionState.waiting &&
+              names.hfName.isNotEmpty) {
             return AlertDialog(
                 title: Text(localizations.slot_settings),
                 content: const SingleChildScrollView(
@@ -115,38 +114,19 @@ class SlotSettingsState extends State<SlotSettings> {
                     const Spacer(
                       flex: 1,
                     ),
-                    Row(
-                      children: [
-                        // IconButton(
-                        //     onPressed: () {
-                        //       showDialog<String>(
-                        //         context: context,
-                        //         builder: (BuildContext context) => AlertDialog(
-                        //           title: Text(localizations.edit_slot_data),
-                        //           content: const Placeholder(),
-                        //         ),
-                        //       );
-                        //     },
-                        //     icon: const Icon(Icons.edit)),
-                        // const SizedBox(width: 8),
-                        IconButton(
-                          onPressed: (usedSlots[widget.slot].$1 !=
-                                      TagType.unknown ||
-                                  usedSlots[widget.slot].$2 != TagType.unknown)
-                              ? () {
-                                  showDialog<String>(
-                                      context: context,
-                                      builder: (BuildContext context) =>
-                                          SlotExportMenu(
-                                              names: [hfName, lfName],
-                                              enabledSlots: enabledSlots,
-                                              usedSlots: usedSlots,
-                                              slot: widget.slot));
-                                }
-                              : null,
-                          icon: const Icon(Icons.download),
-                        ),
-                      ],
+                    IconButton(
+                      onPressed: (slotTypes.notMatch())
+                          ? () {
+                              showDialog<String>(
+                                  context: context,
+                                  builder: (BuildContext context) =>
+                                      SlotExportMenu(
+                                          names: names,
+                                          enabledSlotInfo: enabledSlot,
+                                          slotTypes: slotTypes));
+                            }
+                          : null,
+                      icon: const Icon(Icons.download),
                     ),
                   ],
                 ),
@@ -158,8 +138,18 @@ class SlotSettingsState extends State<SlotSettings> {
                       const SizedBox(width: 8),
                       Expanded(
                           child: OutlinedButton(
-                        onPressed: null,
-                        child: Text(hfName),
+                        onPressed: () async {
+                          showDialog<String>(
+                              context: context,
+                              builder: (BuildContext context) => SlotEditMenu(
+                                  name: names.hfName,
+                                  isEnabled: enabledSlot.hfSlot,
+                                  slotType: slotTypes.hfSlot,
+                                  frequency: TagFrequency.hf,
+                                  slot: widget.slot,
+                                  update: updateSlot));
+                        },
+                        child: Text(names.hfName),
                       )),
                       const SizedBox(width: 8),
                       IconButton(
@@ -173,9 +163,8 @@ class SlotSettingsState extends State<SlotSettings> {
                           await appState.communicator!.saveSlotData();
 
                           setState(() {
-                            hfName = '';
-                            usedSlots[widget.slot] =
-                                (TagType.unknown, usedSlots[widget.slot].$2);
+                            names.hfName = localizations.empty;
+                            slotTypes.hfSlot = TagType.unknown;
                           });
 
                           widget.refresh(widget.slot);
@@ -185,19 +174,16 @@ class SlotSettingsState extends State<SlotSettings> {
                       IconButton(
                         onPressed: () async {
                           await appState.communicator!.enableSlot(widget.slot,
-                              TagFrequency.hf, !enabledSlots[widget.slot].$1);
+                              TagFrequency.hf, !enabledSlot.hfSlot);
                           await appState.communicator!.saveSlotData();
 
                           setState(() {
-                            enabledSlots[widget.slot] = (
-                              !enabledSlots[widget.slot].$1,
-                              enabledSlots[widget.slot].$2
-                            );
+                            enabledSlot.hfSlot = !enabledSlot.hfSlot;
                           });
 
                           widget.refresh(widget.slot);
                         },
-                        icon: Icon(enabledSlots[widget.slot].$1
+                        icon: Icon(enabledSlot.hfSlot
                             ? Icons.toggle_on
                             : Icons.toggle_off),
                       ),
@@ -210,8 +196,18 @@ class SlotSettingsState extends State<SlotSettings> {
                       const SizedBox(width: 8),
                       Expanded(
                           child: OutlinedButton(
-                        onPressed: null,
-                        child: Text(lfName),
+                        onPressed: () async {
+                          showDialog<String>(
+                              context: context,
+                              builder: (BuildContext context) => SlotEditMenu(
+                                  name: names.lfName,
+                                  isEnabled: enabledSlot.lfSlot,
+                                  slotType: slotTypes.lfSlot,
+                                  frequency: TagFrequency.lf,
+                                  slot: widget.slot,
+                                  update: updateSlot));
+                        },
+                        child: Text(names.lfName),
                       )),
                       const SizedBox(width: 8),
                       IconButton(
@@ -225,9 +221,8 @@ class SlotSettingsState extends State<SlotSettings> {
                           await appState.communicator!.saveSlotData();
 
                           setState(() {
-                            lfName = '';
-                            usedSlots[widget.slot] =
-                                (usedSlots[widget.slot].$2, TagType.unknown);
+                            names.lfName = localizations.empty;
+                            slotTypes.lfSlot = TagType.unknown;
                           });
 
                           widget.refresh(widget.slot);
@@ -237,146 +232,21 @@ class SlotSettingsState extends State<SlotSettings> {
                       IconButton(
                         onPressed: () async {
                           await appState.communicator!.enableSlot(widget.slot,
-                              TagFrequency.lf, !enabledSlots[widget.slot].$2);
+                              TagFrequency.lf, !enabledSlot.lfSlot);
                           await appState.communicator!.saveSlotData();
 
                           setState(() {
-                            enabledSlots[widget.slot] = (
-                              enabledSlots[widget.slot].$1,
-                              !enabledSlots[widget.slot].$2
-                            );
+                            enabledSlot.lfSlot = !enabledSlot.lfSlot;
                           });
 
                           widget.refresh(widget.slot);
                         },
-                        icon: Icon(enabledSlots[widget.slot].$2
+                        icon: Icon(enabledSlot.lfSlot
                             ? Icons.toggle_on
                             : Icons.toggle_off),
                       ),
                     ],
                   ),
-                  const SizedBox(height: 16),
-                  Text(
-                    localizations.mifare_classic_emulator_settings,
-                    textScaleFactor: 1.1,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(localizations.mode_gen1a),
-                  const SizedBox(height: 8),
-                  ToggleButtonsWrapper(
-                      items: [localizations.yes, localizations.no],
-                      selectedValue: isGen1a ? 0 : 1,
-                      onChange: (int index) async {
-                        await appState.communicator!.activateSlot(widget.slot);
-                        await appState.communicator!
-                            .setMf1Gen1aMode(index == 0 ? true : false);
-
-                        widget.refresh(widget.slot);
-                      }),
-                  const SizedBox(height: 8),
-                  Text(localizations.mode_gen2),
-                  const SizedBox(height: 8),
-                  ToggleButtonsWrapper(
-                      items: [localizations.yes, localizations.no],
-                      selectedValue: isGen2 ? 0 : 1,
-                      onChange: (int index) async {
-                        await appState.communicator!.activateSlot(widget.slot);
-                        await appState.communicator!
-                            .setMf1Gen2Mode(index == 0 ? true : false);
-
-                        widget.refresh(widget.slot);
-                      }),
-                  const SizedBox(height: 8),
-                  Text(localizations.use_from_block),
-                  const SizedBox(height: 8),
-                  ToggleButtonsWrapper(
-                      items: [localizations.yes, localizations.no],
-                      selectedValue: isAntiColl ? 0 : 1,
-                      onChange: (int index) async {
-                        await appState.communicator!.activateSlot(widget.slot);
-                        await appState.communicator!
-                            .setMf1UseFirstBlockColl(index == 0 ? true : false);
-
-                        widget.refresh(widget.slot);
-                      }),
-                  const SizedBox(height: 8),
-                  Text(localizations.collect_nonces('Mfkey32')),
-                  const SizedBox(height: 8),
-                  ToggleButtonsWrapper(
-                      items: [localizations.yes, localizations.no],
-                      selectedValue: isDetection ? 0 : 1,
-                      onChange: (int index) async {
-                        await appState.communicator!.activateSlot(widget.slot);
-                        await appState.communicator!.setMf1DetectionStatus(
-                            isDetection = index == 0 ? true : false);
-
-                        widget.refresh(widget.slot);
-                      }),
-                  ...(isDetection)
-                      ? [
-                          ...(detectionCount == 0)
-                              ? [
-                                  const SizedBox(height: 8),
-                                  Text(localizations.present_cham_reader_keys,
-                                      textScaleFactor: 0.8)
-                                ]
-                              : [
-                                  const SizedBox(height: 8),
-                                  Row(
-                                      mainAxisAlignment:
-                                          MainAxisAlignment.center,
-                                      children: [
-                                        TextButton(
-                                            onPressed: () {
-                                              Navigator.pop(context);
-                                              appState.forceMfkey32Page = true;
-                                              appState.changesMade();
-                                            },
-                                            child: Row(
-                                              children: [
-                                                const Icon(Icons.lock_open),
-                                                Text(
-                                                    localizations.recover_keys),
-                                              ],
-                                            )),
-                                      ]),
-                                ],
-                        ]
-                      : [
-                          const SizedBox(height: 8),
-                          Text(localizations.ena_coll_recover_keys,
-                              textScaleFactor: 0.8)
-                        ],
-                  const SizedBox(height: 8),
-                  Text(localizations.write_mode),
-                  const SizedBox(height: 8),
-                  ToggleButtonsWrapper(
-                      items: [
-                        localizations.normal,
-                        localizations.decline,
-                        localizations.deceive,
-                        localizations.shadow
-                      ],
-                      selectedValue: writeMode.value,
-                      onChange: (int index) async {
-                        await appState.communicator!.activateSlot(widget.slot);
-
-                        if (index == 0) {
-                          await appState.communicator!
-                              .setMf1WriteMode(MifareClassicWriteMode.normal);
-                        } else if (index == 1) {
-                          await appState.communicator!
-                              .setMf1WriteMode(MifareClassicWriteMode.denied);
-                        } else if (index == 2) {
-                          await appState.communicator!
-                              .setMf1WriteMode(MifareClassicWriteMode.deceive);
-                        } else if (index == 3) {
-                          await appState.communicator!
-                              .setMf1WriteMode(MifareClassicWriteMode.shadow);
-                        }
-
-                        widget.refresh(widget.slot);
-                      }),
                 ])));
           }
         });

--- a/chameleonultragui/lib/gui/page/settings.dart
+++ b/chameleonultragui/lib/gui/page/settings.dart
@@ -273,7 +273,7 @@ class SettingsMainPageState extends State<SettingsMainPage> {
                   ),
                   actions: <Widget>[
                     TextButton(
-                      onPressed: () => Navigator.pop(context, localizations.ok),
+                      onPressed: () => Navigator.pop(context),
                       child: Text(localizations.ok),
                     ),
                   ],
@@ -293,8 +293,7 @@ class SettingsMainPageState extends State<SettingsMainPage> {
                           : localizations.activate.toLowerCase())),
                   actions: <Widget>[
                     TextButton(
-                      onPressed: () =>
-                          Navigator.pop(context, localizations.cancel),
+                      onPressed: () => Navigator.pop(context),
                       child: Text(localizations.cancel),
                     ),
                     TextButton(
@@ -302,7 +301,7 @@ class SettingsMainPageState extends State<SettingsMainPage> {
                         appState.sharedPreferencesProvider.setDebugMode(
                             !appState.sharedPreferencesProvider.isDebugMode());
                         appState.changesMade();
-                        Navigator.pop(context, localizations.ok);
+                        Navigator.pop(context);
                       },
                       child: Text(localizations.ok),
                     ),

--- a/chameleonultragui/lib/gui/page/slot_manager.dart
+++ b/chameleonultragui/lib/gui/page/slot_manager.dart
@@ -73,9 +73,9 @@ class SlotManagerPageState extends State<SlotManagerPage> {
                   .getSlotTagName(index, TagFrequency.hf))
               .trim();
           if (name.isEmpty) {
-            slotData[index].hfName = localizations.empty;
+            slotData[index].hf = localizations.empty;
           } else {
-            slotData[index].hfName = name;
+            slotData[index].hf = name;
           }
         } catch (_) {}
 
@@ -84,9 +84,9 @@ class SlotManagerPageState extends State<SlotManagerPage> {
                   .getSlotTagName(index, TagFrequency.lf))
               .trim();
           if (name.isEmpty) {
-            slotData[index].lfName = localizations.empty;
+            slotData[index].lf = localizations.empty;
           } else {
-            slotData[index].lfName = name;
+            slotData[index].lf = name;
           }
         } catch (_) {}
       }
@@ -302,7 +302,7 @@ class SlotManagerPageState extends State<SlotManagerPage> {
                                       const SizedBox(width: 5),
                                       Expanded(
                                           child: Text(
-                                        "${slotData[index].hfName} (${chameleonTagToString(usedSlots[index].hfSlot)})",
+                                        "${slotData[index].hf} (${chameleonTagToString(usedSlots[index].hf)})",
                                         maxLines: 2,
                                         overflow: TextOverflow.ellipsis,
                                       ))
@@ -319,7 +319,7 @@ class SlotManagerPageState extends State<SlotManagerPage> {
                                             const SizedBox(width: 5),
                                             Expanded(
                                                 child: Text(
-                                              "${slotData[index].lfName} (${chameleonTagToString(usedSlots[index].lfSlot)})",
+                                              "${slotData[index].lf} (${chameleonTagToString(usedSlots[index].lf)})",
                                               //maxLines: 2,
                                               overflow: TextOverflow.clip,
                                             ))

--- a/chameleonultragui/lib/gui/page/slot_manager.dart
+++ b/chameleonultragui/lib/gui/page/slot_manager.dart
@@ -23,25 +23,22 @@ class SlotManagerPage extends StatefulWidget {
 }
 
 class SlotManagerPageState extends State<SlotManagerPage> {
-  List<(TagType, TagType)> usedSlots = List.generate(
+  List<SlotTypes> usedSlots = List.generate(
     8,
-    (_) => (TagType.unknown, TagType.unknown),
+    (_) => SlotTypes(),
   );
 
-  List<(bool, bool)> enabledSlots = List.generate(
+  List<EnabledSlotInfo> enabledSlots = List.generate(
     8,
-    (_) => (true, true),
+    (_) => EnabledSlotInfo(),
   );
 
-  List<Map<String, String>> slotData = List.generate(
+  List<SlotNames> slotData = List.generate(
     8,
-    (_) => {
-      'hfName': '...',
-      'lfName': '...',
-    },
+    (_) => SlotNames(),
   );
 
-  int currentFunctionIndex = 0;
+  int index = 0;
   int progress = -1;
   int gridPosition = 0;
   bool onlyOneSlot = false;
@@ -50,9 +47,9 @@ class SlotManagerPageState extends State<SlotManagerPage> {
     var appState = context.read<ChameleonGUIState>();
     var localizations = AppLocalizations.of(context)!;
 
-    if (currentFunctionIndex == 0 || onlyOneSlot) {
+    if (index == 0 || onlyOneSlot) {
       try {
-        usedSlots = await appState.communicator!.getUsedSlots();
+        usedSlots = await appState.communicator!.getSlotTagTypes();
       } catch (_) {
         try {
           await appState.communicator!.getFirmwareVersion();
@@ -67,43 +64,40 @@ class SlotManagerPageState extends State<SlotManagerPage> {
       } catch (_) {}
     }
 
-    if (currentFunctionIndex < 8) {
-      slotData[currentFunctionIndex]['hfName'] = "";
-      slotData[currentFunctionIndex]['lfName'] = "";
+    if (index < 8) {
+      slotData[index] = SlotNames();
 
       for (var i = 0; i < 2; i++) {
         try {
-          slotData[currentFunctionIndex]['hfName'] = await appState
-              .communicator!
-              .getSlotTagName(currentFunctionIndex, TagFrequency.hf);
-          break;
+          String name = (await appState.communicator!
+                  .getSlotTagName(index, TagFrequency.hf))
+              .trim();
+          if (name.isEmpty) {
+            slotData[index].hfName = localizations.empty;
+          } else {
+            slotData[index].hfName = name;
+          }
         } catch (_) {}
-      }
 
-      if (slotData[currentFunctionIndex]['hfName']!.isEmpty) {
-        slotData[currentFunctionIndex]['hfName'] = localizations.empty;
-      }
-
-      for (var i = 0; i < 2; i++) {
         try {
-          slotData[currentFunctionIndex]['lfName'] = await appState
-              .communicator!
-              .getSlotTagName(currentFunctionIndex, TagFrequency.lf);
-          break;
+          String name = (await appState.communicator!
+                  .getSlotTagName(index, TagFrequency.lf))
+              .trim();
+          if (name.isEmpty) {
+            slotData[index].lfName = localizations.empty;
+          } else {
+            slotData[index].lfName = name;
+          }
         } catch (_) {}
-      }
-
-      if (slotData[currentFunctionIndex]['lfName']!.isEmpty) {
-        slotData[currentFunctionIndex]['lfName'] = localizations.empty;
       }
 
       if (!onlyOneSlot) {
         setState(() {
-          currentFunctionIndex++;
+          index++;
         });
       } else {
         setState(() {
-          currentFunctionIndex = 8;
+          index = 8;
         });
       }
     }
@@ -112,7 +106,7 @@ class SlotManagerPageState extends State<SlotManagerPage> {
   void refreshSlot(int slot) {
     setUploadState(-1);
     setState(() {
-      currentFunctionIndex = slot;
+      index = slot;
       onlyOneSlot = true;
     });
     var appState = context.read<ChameleonGUIState>();
@@ -127,146 +121,11 @@ class SlotManagerPageState extends State<SlotManagerPage> {
     appState.changesMade();
   }
 
-  @override
-  Widget build(BuildContext context) {
-    var localizations = AppLocalizations.of(context)!;
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(localizations.slot_manager),
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            FutureBuilder(
-              future: executeNextFunction(),
-              builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
-                return Expanded(
-                  child: AlignedGridView.count(
-                      padding: const EdgeInsets.all(20),
-                      crossAxisCount:
-                          MediaQuery.of(context).size.width >= 700 ? 2 : 1,
-                      crossAxisSpacing: 10,
-                      mainAxisSpacing: 10,
-                      itemCount: 8,
-                      itemBuilder: (BuildContext context, int index) {
-                        return Container(
-                          constraints: const BoxConstraints(
-                              maxHeight: 160, minHeight: 100),
-                          child: ElevatedButton(
-                            onPressed: () {
-                              setState(() {
-                                gridPosition = index;
-                              });
-                              cardSelectDialog(context);
-                            },
-                            style: ButtonStyle(
-                              shape: MaterialStateProperty.all<
-                                  RoundedRectangleBorder>(
-                                RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(18.0),
-                                ),
-                              ),
-                            ),
-                            child: Padding(
-                              padding: const EdgeInsets.only(
-                                  top: 8.0, left: 8.0, bottom: 6.0),
-                              child: Column(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                  Row(
-                                    children: [
-                                      Icon(Icons.nfc,
-                                          color: enabledSlots[index].$1 ||
-                                                  enabledSlots[index].$2
-                                              ? Colors.green
-                                              : Colors.deepOrange),
-                                      const SizedBox(width: 5),
-                                      Expanded(
-                                        child: Text(
-                                          "${localizations.slot} ${index + 1}",
-                                          maxLines: 2,
-                                          overflow: TextOverflow.ellipsis,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                  const SizedBox(height: 20),
-                                  Row(
-                                    mainAxisAlignment: MainAxisAlignment.start,
-                                    children: [
-                                      const Icon(Icons.credit_card),
-                                      const SizedBox(width: 5),
-                                      Expanded(
-                                          child: Text(
-                                        "${slotData[index]['hfName'] ?? localizations.unknown} (${chameleonTagToString(usedSlots[index].$1)})",
-                                        maxLines: 2,
-                                        overflow: TextOverflow.ellipsis,
-                                      ))
-                                    ],
-                                  ),
-                                  Row(
-                                    children: [
-                                      Expanded(
-                                        child: Row(
-                                          mainAxisAlignment:
-                                              MainAxisAlignment.start,
-                                          children: [
-                                            const Icon(Icons.wifi),
-                                            const SizedBox(width: 5),
-                                            Expanded(
-                                                child: Text(
-                                              "${slotData[index]['lfName'] ?? localizations.unknown} (${chameleonTagToString(usedSlots[index].$2)})",
-                                              //maxLines: 2,
-                                              overflow: TextOverflow.clip,
-                                            ))
-                                          ],
-                                        ),
-                                      ),
-                                      IconButton(
-                                        onPressed: () {
-                                          showDialog(
-                                            context: context,
-                                            builder: (BuildContext context) {
-                                              return SlotSettings(
-                                                  slot: index,
-                                                  refresh: refreshSlot);
-                                            },
-                                          );
-                                        },
-                                        icon: const Icon(Icons.settings),
-                                      ),
-                                    ],
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ),
-                        );
-                      }),
-                );
-              },
-            ),
-            if (progress != -1)
-              LinearProgressIndicator(
-                value: (progress / 100).toDouble(),
-              )
-          ],
-        ),
-      ),
-    );
-  }
-
   Future<void> onTap(CardSave card, dynamic close) async {
     var appState = Provider.of<ChameleonGUIState>(context, listen: false);
     var localizations = AppLocalizations.of(context)!;
 
-    if ([
-      TagType.mifareMini,
-      TagType.mifare1K,
-      TagType.mifare2K,
-      TagType.mifare4K
-    ].contains(card.tag)) {
+    if (isMifareClassic(card.tag)) {
       close(context, card.name);
       setUploadState(0);
       var isEV1 = chameleonTagSaveCheckForMifareClassicEV1(card);
@@ -369,6 +228,135 @@ class SlotManagerPageState extends State<SlotManagerPage> {
     return showSearch<String>(
       context: context,
       delegate: CardSearchDelegate(cards: tags, onTap: onTap),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var localizations = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(localizations.slot_manager),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            FutureBuilder(
+              future: executeNextFunction(),
+              builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
+                return Expanded(
+                  child: AlignedGridView.count(
+                      padding: const EdgeInsets.all(20),
+                      crossAxisCount:
+                          MediaQuery.of(context).size.width >= 700 ? 2 : 1,
+                      crossAxisSpacing: 10,
+                      mainAxisSpacing: 10,
+                      itemCount: 8,
+                      itemBuilder: (BuildContext context, int index) {
+                        return Container(
+                          constraints: const BoxConstraints(
+                              maxHeight: 160, minHeight: 100),
+                          child: ElevatedButton(
+                            onPressed: () {
+                              setState(() {
+                                gridPosition = index;
+                              });
+                              cardSelectDialog(context);
+                            },
+                            style: ButtonStyle(
+                              shape: MaterialStateProperty.all<
+                                  RoundedRectangleBorder>(
+                                RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(18.0),
+                                ),
+                              ),
+                            ),
+                            child: Padding(
+                              padding: const EdgeInsets.only(
+                                  top: 8.0, left: 8.0, bottom: 6.0),
+                              child: Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Row(
+                                    children: [
+                                      Icon(Icons.nfc,
+                                          color: enabledSlots[index].any()
+                                              ? Colors.green
+                                              : Colors.deepOrange),
+                                      const SizedBox(width: 5),
+                                      Expanded(
+                                        child: Text(
+                                          "${localizations.slot} ${index + 1}",
+                                          maxLines: 2,
+                                          overflow: TextOverflow.ellipsis,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  const SizedBox(height: 20),
+                                  Row(
+                                    mainAxisAlignment: MainAxisAlignment.start,
+                                    children: [
+                                      const Icon(Icons.credit_card),
+                                      const SizedBox(width: 5),
+                                      Expanded(
+                                          child: Text(
+                                        "${slotData[index].hfName} (${chameleonTagToString(usedSlots[index].hfSlot)})",
+                                        maxLines: 2,
+                                        overflow: TextOverflow.ellipsis,
+                                      ))
+                                    ],
+                                  ),
+                                  Row(
+                                    children: [
+                                      Expanded(
+                                        child: Row(
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.start,
+                                          children: [
+                                            const Icon(Icons.wifi),
+                                            const SizedBox(width: 5),
+                                            Expanded(
+                                                child: Text(
+                                              "${slotData[index].lfName} (${chameleonTagToString(usedSlots[index].lfSlot)})",
+                                              //maxLines: 2,
+                                              overflow: TextOverflow.clip,
+                                            ))
+                                          ],
+                                        ),
+                                      ),
+                                      IconButton(
+                                        onPressed: () {
+                                          showDialog(
+                                            context: context,
+                                            builder: (BuildContext context) {
+                                              return SlotSettings(
+                                                  slot: index,
+                                                  refresh: refreshSlot);
+                                            },
+                                          );
+                                        },
+                                        icon: const Icon(Icons.settings),
+                                      ),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        );
+                      }),
+                );
+              },
+            ),
+            if (progress != -1)
+              LinearProgressIndicator(
+                value: (progress / 100).toDouble(),
+              )
+          ],
+        ),
+      ),
     );
   }
 }

--- a/chameleonultragui/lib/helpers/general.dart
+++ b/chameleonultragui/lib/helpers/general.dart
@@ -42,6 +42,10 @@ Uint8List hexToBytesSpace(String hex) {
   return hexToBytes(hex.replaceAll(" ", ""));
 }
 
+int bytesToU8(Uint8List byteArray) {
+  return byteArray.buffer.asByteData().getUint8(0);
+}
+
 int bytesToU16(Uint8List byteArray) {
   return byteArray.buffer.asByteData().getUint16(0, Endian.big);
 }
@@ -293,4 +297,22 @@ void updateNavigationRailWidth(BuildContext context) async {
         appState.navigationRailKey.currentContext!.size;
     appState.changesMade();
   }
+}
+
+List<TagType> getTagTypeByFrequency(TagFrequency frequency) {
+  if (frequency == TagFrequency.hf) {
+    return [
+      TagType.mifare1K,
+      TagType.mifare2K,
+      TagType.mifare4K,
+      TagType.mifareMini,
+      TagType.ntag213,
+      TagType.ntag215,
+      TagType.ntag216,
+    ];
+  } else if (frequency == TagFrequency.lf) {
+    return [TagType.em410X];
+  }
+
+  return [TagType.unknown];
 }

--- a/chameleonultragui/lib/helpers/ntag/general.dart
+++ b/chameleonultragui/lib/helpers/ntag/general.dart
@@ -1,0 +1,5 @@
+import 'package:chameleonultragui/bridge/chameleon.dart';
+
+bool isNTAG(TagType type) {
+  return [TagType.ntag213, TagType.ntag215, TagType.ntag216].contains(type);
+}

--- a/chameleonultragui/lib/l10n/app_en.arb
+++ b/chameleonultragui/lib/l10n/app_en.arb
@@ -224,5 +224,6 @@
   "frequency_to_export": "Frequency to export",
   "save_to_file": "Save to file",
   "export_to_new_card": "Export to new card",
-  "update_saved_card": "Update saved card"
+  "update_saved_card": "Update saved card",
+  "must_be_valid_hex": "Must be valid HEX"
 }

--- a/chameleonultragui/lib/main.dart
+++ b/chameleonultragui/lib/main.dart
@@ -113,12 +113,13 @@ class _MainPageState extends State<MainPage> {
   }
 
   @override
-  void reassemble() {
-    super.reassemble();
-
+  void reassemble() async {
     // Disconnect on reload
     var appState = Provider.of<ChameleonGUIState>(context, listen: false);
-    appState.connector?.performDisconnect();
+    await appState.connector?.performDisconnect();
+    appState.changesMade();
+
+    super.reassemble();
   }
 
   @override


### PR DESCRIPTION
Something is done on purpose:
You can't access Mifare Classic emulator settings before loading data to slot
Mifare Classic emulator settings are changed independently from UID (without clicking save button)
Restricted access to NTAG (not supported by firmware, don't let users to break whole app)
Unknown tag type can't be saved (as data wiping done by other button)

Fixed a lot of bugs, code quality improved

Closes #182