### PR TITLE
feat: add confirm deletion to all major destructive actions (toggleable)

### DIFF
--- a/chameleonultragui/lib/gui/menu/card_view.dart
+++ b/chameleonultragui/lib/gui/menu/card_view.dart
@@ -8,6 +8,7 @@ import 'package:chameleonultragui/sharedprefsprovider.dart';
 import 'package:provider/provider.dart';
 import 'package:chameleonultragui/main.dart';
 import 'package:flutter/services.dart';
+import 'package:chameleonultragui/gui/menu/confirm_delete.dart';
 
 // Localizations
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -173,6 +174,18 @@ class CardViewMenuState extends State<CardViewMenu> {
         ),
         IconButton(
           onPressed: () async {
+            if (appState.sharedPreferencesProvider.getConfirmDelete() == true) {
+              var confirm = await showDialog(
+                context: context,
+                builder: (BuildContext context) {
+                  return ConfirmDeletionMenu(thingBeingDeleted: widget.tagSave.name);
+                },
+              );
+
+              if (confirm != true) {
+                return;
+              }
+            }
             var tags = appState.sharedPreferencesProvider.getCards();
             List<CardSave> output = [];
             for (var tagTest in tags) {
@@ -182,7 +195,9 @@ class CardViewMenuState extends State<CardViewMenu> {
             }
             appState.sharedPreferencesProvider.setCards(output);
             appState.changesMade();
-            Navigator.pop(context);
+            if (context.mounted) {
+              Navigator.pop(context);
+            }
           },
           icon: const Icon(Icons.delete_outline),
         ),

--- a/chameleonultragui/lib/gui/menu/confirm_delete.dart
+++ b/chameleonultragui/lib/gui/menu/confirm_delete.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+// Localizations
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class ConfirmDeletionMenu extends StatefulWidget {
+  final String thingBeingDeleted;
+
+  const ConfirmDeletionMenu({super.key, required this.thingBeingDeleted});
+
+  @override
+  ConfirmDeletionMenuState createState() => ConfirmDeletionMenuState();
+}
+
+class ConfirmDeletionMenuState extends State<ConfirmDeletionMenu> {
+  @override
+  Widget build(BuildContext context) {
+    var localizations = AppLocalizations.of(context)!;
+
+    return AlertDialog(
+      title: Text(localizations.confirm_deletion),
+      content: SingleChildScrollView(
+          child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          Text(localizations.confirm_deletion_text("\"${widget.thingBeingDeleted}\"")),
+        ],
+      )),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop(false);
+          },
+          child: Text(localizations.cancel),
+        ),
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop(true);
+          },
+          child: Text(localizations.delete),
+        ),
+      ],
+    );
+  }
+}

--- a/chameleonultragui/lib/gui/menu/dictionary_view.dart
+++ b/chameleonultragui/lib/gui/menu/dictionary_view.dart
@@ -9,6 +9,7 @@ import 'package:chameleonultragui/main.dart';
 import 'package:flutter/services.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:file_saver/file_saver.dart';
+import 'package:chameleonultragui/gui/menu/confirm_delete.dart';
 
 // Localizations
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -119,6 +120,19 @@ class DictionaryViewMenuState extends State<DictionaryViewMenu> {
         ),
         IconButton(
           onPressed: () async {
+            if (appState.sharedPreferencesProvider.getConfirmDelete() == true) {
+              var confirm = await showDialog(
+                context: context,
+                builder: (BuildContext context) {
+                  return ConfirmDeletionMenu(
+                      thingBeingDeleted: widget.dictionary.name);
+                },
+              );
+
+              if (confirm != true) {
+                return;
+              }
+            }
             var dictionaries =
                 appState.sharedPreferencesProvider.getDictionaries();
             List<Dictionary> output = [];

--- a/chameleonultragui/lib/gui/menu/slot_settings.dart
+++ b/chameleonultragui/lib/gui/menu/slot_settings.dart
@@ -4,6 +4,7 @@ import 'package:chameleonultragui/gui/menu/slot_export.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:chameleonultragui/main.dart';
+import 'package:chameleonultragui/gui/menu/confirm_delete.dart';
 
 // Localizations
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -167,6 +168,21 @@ class SlotSettingsState extends State<SlotSettings> {
                       ),
                       IconButton(
                         onPressed: () async {
+                          if (appState.sharedPreferencesProvider
+                                  .getConfirmDelete() ==
+                              true) {
+                            var confirm = await showDialog(
+                              context: context,
+                              builder: (BuildContext context) {
+                                return ConfirmDeletionMenu(
+                                    thingBeingDeleted: names.hf);
+                              },
+                            );
+
+                            if (confirm != true) {
+                              return;
+                            }
+                          }
                           await appState.communicator!
                               .deleteSlotInfo(widget.slot, TagFrequency.hf);
                           await appState.communicator!.setSlotTagName(
@@ -226,6 +242,21 @@ class SlotSettingsState extends State<SlotSettings> {
                       ),
                       IconButton(
                         onPressed: () async {
+                          if (appState.sharedPreferencesProvider
+                                  .getConfirmDelete() ==
+                              true) {
+                            var confirm = await showDialog(
+                              context: context,
+                              builder: (BuildContext context) {
+                                return ConfirmDeletionMenu(
+                                    thingBeingDeleted: names.lf);
+                              },
+                            );
+
+                            if (confirm != true) {
+                              return;
+                            }
+                          }
                           await appState.communicator!
                               .deleteSlotInfo(widget.slot, TagFrequency.lf);
                           await appState.communicator!.setSlotTagName(

--- a/chameleonultragui/lib/gui/page/saved_cards.dart
+++ b/chameleonultragui/lib/gui/page/saved_cards.dart
@@ -18,6 +18,7 @@ import 'package:provider/provider.dart';
 import 'package:chameleonultragui/gui/menu/card_edit.dart';
 import 'package:chameleonultragui/gui/menu/dictionary_view.dart';
 import 'package:uuid/uuid.dart';
+import 'package:chameleonultragui/gui/menu/confirm_delete.dart';
 
 // Localizations
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -542,6 +543,21 @@ class SavedCardsPageState extends State<SavedCardsPage> {
                                 ),
                                 IconButton(
                                   onPressed: () async {
+                                    if (appState.sharedPreferencesProvider
+                                            .getConfirmDelete() ==
+                                        true) {
+                                      var confirm = await showDialog(
+                                        context: context,
+                                        builder: (BuildContext context) {
+                                          return ConfirmDeletionMenu(
+                                              thingBeingDeleted: tag.name);
+                                        },
+                                      );
+
+                                      if (confirm != true) {
+                                        return;
+                                      }
+                                    }
                                     var tags = appState
                                         .sharedPreferencesProvider
                                         .getCards();
@@ -703,6 +719,22 @@ class SavedCardsPageState extends State<SavedCardsPage> {
                                 ),
                                 IconButton(
                                   onPressed: () async {
+                                    if (appState.sharedPreferencesProvider
+                                            .getConfirmDelete() ==
+                                        true) {
+                                      var confirm = await showDialog(
+                                        context: context,
+                                        builder: (BuildContext context) {
+                                          return ConfirmDeletionMenu(
+                                              thingBeingDeleted:
+                                                  dictionary.name);
+                                        },
+                                      );
+
+                                      if (confirm != true) {
+                                        return;
+                                      }
+                                    }
                                     var dictionaries = appState
                                         .sharedPreferencesProvider
                                         .getDictionaries();

--- a/chameleonultragui/lib/gui/page/settings.dart
+++ b/chameleonultragui/lib/gui/page/settings.dart
@@ -233,6 +233,26 @@ class SettingsMainPageState extends State<SettingsMainPage> {
                 ),
               ),
               const SizedBox(height: 10),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    localizations.confirm_deletions,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(width: 5),
+                  Switch(
+                    value: appState.sharedPreferencesProvider
+                        .getConfirmDelete(),
+                    onChanged: (value) async {
+                      appState.sharedPreferencesProvider
+                          .setConfirmDelete(value);
+                      appState.changesMade();
+                    },
+                  ),
+                ],
+              ),
+              const SizedBox(height: 10),
               FittedBox(
                 fit: BoxFit.scaleDown,
                 child: TextButton(

--- a/chameleonultragui/lib/l10n/app_en.arb
+++ b/chameleonultragui/lib/l10n/app_en.arb
@@ -272,5 +272,9 @@
   "next": "Next",
   "back": "Back",
   "reset": "Reset",
-  "write_again": "Write again"
+  "write_again": "Write again",
+  "confirm_deletions": "Confirm deletions",
+  "confirm_deletion": "Confirm deletion",
+  "confirm_deletion_text": "Are you sure you want to delete {name}?",
+  "delete": "Delete"
 }

--- a/chameleonultragui/lib/sharedprefsprovider.dart
+++ b/chameleonultragui/lib/sharedprefsprovider.dart
@@ -362,4 +362,12 @@ class SharedPreferencesProvider extends ChangeNotifier {
       }
     }
   }
+
+  bool getConfirmDelete() {
+    return _sharedPreferences.getBool('confirm_delete') ?? true;
+  }
+
+  void setConfirmDelete(bool value) {
+    _sharedPreferences.setBool('confirm_delete', value);
+  }
 }

--- a/chameleonultragui/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/chameleonultragui/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -18,7 +18,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSaverPlugin.register(with: registry.registrar(forPlugin: "FileSaverPlugin"))
   FlutterLibserialportPlugin.register(with: registry.registrar(forPlugin: "FlutterLibserialportPlugin"))
   MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
-  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))


### PR DESCRIPTION
Can be toggled on and of in settings.
"Major destructive actions":
- Deleting dictionary
- Deleting card
- Clearing slot
closes #390 