### PR TITLE
Key recovery improvements

### DIFF
--- a/chameleonultragui/lib/gui/component/card_recovery.dart
+++ b/chameleonultragui/lib/gui/component/card_recovery.dart
@@ -325,47 +325,50 @@ class CardRecoveryState extends State<CardRecovery> {
             child: Text(localizations.check_keys_dict),
           ),
           const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: (widget.mfcInfo.state == MifareClassicState.checkKeys)
-                ? () async {
-                    setState(() {
-                      widget.mfcInfo.state =
-                          MifareClassicState.checkKeysOngoing;
-                    });
-
-                    try {
-                      await widget.mfcInfo.recovery!.autopwn();
-
-                      if (widget.mfcInfo.recovery!.allKeysExists) {
-                        // all keys exists
+          Tooltip(
+            message: localizations.automatic_recovery_less_control,
+            child: ElevatedButton(
+              onPressed: (widget.mfcInfo.state == MifareClassicState.checkKeys)
+                  ? () async {
+                      setState(() {
+                        widget.mfcInfo.state =
+                            MifareClassicState.checkKeysOngoing;
+                      });
+            
+                      try {
+                        await widget.mfcInfo.recovery!.autopwn();
+            
+                        if (widget.mfcInfo.recovery!.allKeysExists) {
+                          // all keys exists
+                          setState(() {
+                            widget.mfcInfo.state = MifareClassicState.dump;
+                          });
+                        } else {
+                          setState(() {
+                            widget.mfcInfo.state = MifareClassicState.checkKeys;
+                          });
+                        }
+                      } catch (_) {
+                        for (var checkmark = 0; checkmark < 80; checkmark++) {
+                          if (widget.mfcInfo.recovery?.checkMarks[checkmark] ==
+                              ChameleonKeyCheckmark.checking) {
+                            widget.mfcInfo.recovery?.checkMarks[checkmark] =
+                                ChameleonKeyCheckmark.none;
+                          }
+                        }
+            
                         setState(() {
-                          widget.mfcInfo.state = MifareClassicState.dump;
-                        });
-                      } else {
-                        setState(() {
+                          widget.mfcInfo.recovery?.checkMarks =
+                              widget.mfcInfo.recovery!.checkMarks;
+                          widget.mfcInfo.recovery?.error =
+                              localizations.automatic_recovery_error;
                           widget.mfcInfo.state = MifareClassicState.checkKeys;
                         });
                       }
-                    } catch (_) {
-                      for (var checkmark = 0; checkmark < 80; checkmark++) {
-                        if (widget.mfcInfo.recovery?.checkMarks[checkmark] ==
-                            ChameleonKeyCheckmark.checking) {
-                          widget.mfcInfo.recovery?.checkMarks[checkmark] =
-                              ChameleonKeyCheckmark.none;
-                        }
-                      }
-
-                      setState(() {
-                        widget.mfcInfo.recovery?.checkMarks =
-                            widget.mfcInfo.recovery!.checkMarks;
-                        widget.mfcInfo.recovery?.error =
-                            localizations.autopwn_error;
-                        widget.mfcInfo.state = MifareClassicState.checkKeys;
-                      });
                     }
-                  }
-                : null,
-            child: Text(localizations.check_keys_autopwn),
+                  : null,
+              child: Text(localizations.try_automatic_recovery),
+            ),
           )
         ]),
       if ((widget.mfcInfo.state == MifareClassicState.dump ||

--- a/chameleonultragui/lib/gui/component/card_recovery.dart
+++ b/chameleonultragui/lib/gui/component/card_recovery.dart
@@ -323,6 +323,49 @@ class CardRecoveryState extends State<CardRecovery> {
                   }
                 : null,
             child: Text(localizations.check_keys_dict),
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: (widget.mfcInfo.state == MifareClassicState.checkKeys)
+                ? () async {
+                    setState(() {
+                      widget.mfcInfo.state =
+                          MifareClassicState.checkKeysOngoing;
+                    });
+
+                    try {
+                      await widget.mfcInfo.recovery!.autopwn();
+
+                      if (widget.mfcInfo.recovery!.allKeysExists) {
+                        // all keys exists
+                        setState(() {
+                          widget.mfcInfo.state = MifareClassicState.dump;
+                        });
+                      } else {
+                        setState(() {
+                          widget.mfcInfo.state = MifareClassicState.checkKeys;
+                        });
+                      }
+                    } catch (_) {
+                      for (var checkmark = 0; checkmark < 80; checkmark++) {
+                        if (widget.mfcInfo.recovery?.checkMarks[checkmark] ==
+                            ChameleonKeyCheckmark.checking) {
+                          widget.mfcInfo.recovery?.checkMarks[checkmark] =
+                              ChameleonKeyCheckmark.none;
+                        }
+                      }
+
+                      setState(() {
+                        widget.mfcInfo.recovery?.checkMarks =
+                            widget.mfcInfo.recovery!.checkMarks;
+                        widget.mfcInfo.recovery?.error =
+                            localizations.autopwn_error;
+                        widget.mfcInfo.state = MifareClassicState.checkKeys;
+                      });
+                    }
+                  }
+                : null,
+            child: Text(localizations.check_keys_autopwn),
           )
         ]),
       if ((widget.mfcInfo.state == MifareClassicState.dump ||

--- a/chameleonultragui/lib/helpers/mifare_classic/general.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/general.dart
@@ -156,7 +156,9 @@ MifareClassicType mfClassicGetCardTypeByBlockCount(int blockCount) {
 }
 
 int mfClassicGetSectorTrailerBlockBySector(int sector) {
-  if (sector < 32) {
+  if (sector == 0) {
+    return 3;
+  } else if (sector < 32) {
     return sector * 4 + 3;
   } else {
     return 32 * 4 + (sector - 32) * 16 + 15;

--- a/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
@@ -329,9 +329,9 @@ class MifareClassicRecovery {
                   if ((await appState.communicator!.mf1Auth(
                       mfClassicGetSectorTrailerBlockBySector(sector),
                       0x60 + keyType,
-                      keyBytes.sublist(2, 8)))) {
+                      keyBytes))) {
                     appState.log!.i(
-                        "Found valid key! Key ${bytesToHex(keyBytes.sublist(2, 8))}");
+                        "Found valid key! Key ${bytesToHex(keyBytes)}");
                     found = true;
                     validKeys[sector + (keyType * 40)] = keyBytes;
                     checkMarks[sector + (keyType * 40)] =

--- a/chameleonultragui/lib/l10n/app_en.arb
+++ b/chameleonultragui/lib/l10n/app_en.arb
@@ -167,8 +167,8 @@
   "dump_partial_data": "Dump partial data",
   "additional_key_dict": "Additional key dictionary",
   "check_keys_dict": "Check keys from dictionary",
-  "check_keys_autopwn": "Try automatic recovery",	
-  "autopwn_error": "Something went wrong in automatic recovery",
+  "try_automatic_recovery": "Try automatic recovery",	
+  "automatic_recovery_error": "Something went wrong in automatic recovery",
   "dump_card": "Dump card",
   "save_as": "Save as {name}",
   "correct_tag_data": "Correct tag details",
@@ -278,5 +278,6 @@
   "confirm_deletions": "Confirm deletions",
   "confirm_deletion": "Confirm deletion",
   "confirm_deletion_text": "Are you sure you want to delete {name}?",
-  "delete": "Delete"
+  "delete": "Delete",
+  "automatic_recovery_less_control": "Automatic recovery tries its best to maximize speed but offers less control"
 }

--- a/chameleonultragui/lib/l10n/app_en.arb
+++ b/chameleonultragui/lib/l10n/app_en.arb
@@ -167,6 +167,8 @@
   "dump_partial_data": "Dump partial data",
   "additional_key_dict": "Additional key dictionary",
   "check_keys_dict": "Check keys from dictionary",
+  "check_keys_autopwn": "Try automatic recovery",	
+  "autopwn_error": "Something went wrong in automatic recovery",
   "dump_card": "Dump card",
   "save_as": "Save as {name}",
   "correct_tag_data": "Correct tag details",


### PR DESCRIPTION
- Bugfix: Calculated nested key recheck didn't work.
- Bugfix: If sector is 0 in mfClassicGetSectorTrailerBlockBySector() it didnt return 3. 
- Added: Automatic key recovery. Try dictionary and switch to Nested recovery after.

