### PR TITLE
Fix settings export as json

### DIFF
--- a/chameleonultragui/lib/sharedprefsprovider.dart
+++ b/chameleonultragui/lib/sharedprefsprovider.dart
@@ -320,7 +320,7 @@ class SharedPreferencesProvider extends ChangeNotifier {
       if (value == null) {
         continue;
       }
-      if (value is List<String>) {
+      if (value is List) {
         // this hack is needed in order to output proper json with objects instead of objects-in-strings
         value = value.map((e) => jsonDecode(e)).toList();
       }


### PR DESCRIPTION
Root cause was that sometimes lists were List<string> but other times they were List<dynamic>.
The fix was broadening the comparison to just List because all Lists saved to shared prefs are in fact lists of string.

This should fix settings serialization issues for good (I certainly hope so lol)