### PR TITLE
feat: Update button style

### DIFF
--- a/chameleonultragui/lib/gui/component/card_button.dart
+++ b/chameleonultragui/lib/gui/component/card_button.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:chameleonultragui/main.dart';
+
+ButtonStyle customCardButtonStyle(ChameleonGUIState appState) {
+  return ButtonStyle(
+    backgroundColor: WidgetStateProperty.resolveWith<Color>(
+      (Set<WidgetState> states) {
+        return appState.sharedPreferencesProvider.getThemeComplementaryColor();
+      },
+    ),
+    shape: WidgetStateProperty.all<RoundedRectangleBorder>(
+      RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(18.0),
+      ),
+    ),
+  );
+}

--- a/chameleonultragui/lib/gui/component/mifare/classic.dart
+++ b/chameleonultragui/lib/gui/component/mifare/classic.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:chameleonultragui/bridge/chameleon.dart';
+import 'package:chameleonultragui/gui/component/card_button.dart';
 import 'package:chameleonultragui/gui/component/error_message.dart';
 import 'package:chameleonultragui/gui/component/key_check_marks.dart';
 import 'package:chameleonultragui/gui/menu/dictionary_export.dart';
@@ -201,6 +202,7 @@ class CardReaderState extends State<MifareClassicHelper> {
                               }
                             }
                           : null,
+                      style: customCardButtonStyle(appState),
                       child: Text(localizations.recover_keys),
                     ),
                     if (widget.allowSave) ...[
@@ -232,6 +234,7 @@ class CardReaderState extends State<MifareClassicHelper> {
                                 }
                               }
                             : null,
+                        style: customCardButtonStyle(appState),
                         child: Text(localizations.dump_partial_data),
                       )
                     ],
@@ -240,6 +243,7 @@ class CardReaderState extends State<MifareClassicHelper> {
                       onPressed: () async {
                         await exportFoundKeys();
                       },
+                      style: customCardButtonStyle(appState),
                       child: Text(localizations.export_to_dictionary),
                     ),
                   ])),
@@ -328,6 +332,7 @@ class CardReaderState extends State<MifareClassicHelper> {
                       }
                     }
                   : null,
+              style: customCardButtonStyle(appState),
               child: Text(localizations.check_keys_dict),
             )
           ]),
@@ -369,6 +374,7 @@ class CardReaderState extends State<MifareClassicHelper> {
                   onPressed: () async {
                     await exportFoundKeys();
                   },
+                  style: customCardButtonStyle(appState),
                   child: Text(localizations.export_to_dictionary),
                 ),
               ])),
@@ -415,6 +421,7 @@ class CardReaderState extends State<MifareClassicHelper> {
                     },
                   );
                 },
+                style: customCardButtonStyle(appState),
                 child: Text(localizations.save),
               ),
               const SizedBox(width: 8),
@@ -422,6 +429,7 @@ class CardReaderState extends State<MifareClassicHelper> {
                 onPressed: () async {
                   await saveCard(bin: true);
                 },
+                style: customCardButtonStyle(appState),
                 child: Text(localizations.save_as(".bin")),
               ),
             ])),

--- a/chameleonultragui/lib/gui/component/mifare/ultralight.dart
+++ b/chameleonultragui/lib/gui/component/mifare/ultralight.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:chameleonultragui/gui/component/card_button.dart';
 import 'package:chameleonultragui/gui/component/error_message.dart';
 import 'package:chameleonultragui/gui/page/read_card.dart';
 import 'package:chameleonultragui/helpers/general.dart';
@@ -155,6 +156,7 @@ class CardReaderState extends State<MifareUltralightHelper> {
 
   @override
   Widget build(BuildContext context) {
+    var appState = Provider.of<ChameleonGUIState>(context, listen: false);
     var localizations = AppLocalizations.of(context)!;
 
     return Column(
@@ -254,6 +256,7 @@ class CardReaderState extends State<MifareUltralightHelper> {
                       },
                     );
                   },
+                  style: customCardButtonStyle(appState),
                   child: Text(localizations.save),
                 ),
                 const SizedBox(width: 8),
@@ -261,6 +264,7 @@ class CardReaderState extends State<MifareUltralightHelper> {
                   onPressed: () async {
                     await saveCard(bin: true);
                   },
+                  style: customCardButtonStyle(appState),
                   child: Text(localizations.save_as(".bin")),
                 ),
               ])),

--- a/chameleonultragui/lib/gui/component/saved_card.dart
+++ b/chameleonultragui/lib/gui/component/saved_card.dart
@@ -1,4 +1,5 @@
 import 'package:chameleonultragui/main.dart';
+import 'package:chameleonultragui/gui/component/card_button.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -62,19 +63,7 @@ class SavedCardState extends State<SavedCard> {
         constraints: BoxConstraints(maxHeight: !shouldMoveIcons() ? 90 : 130),
         child: ElevatedButton(
             onPressed: widget.onPressed,
-            style: ButtonStyle(
-              backgroundColor: WidgetStateProperty.resolveWith<Color>(
-                (Set<WidgetState> states) {
-                  return appState.sharedPreferencesProvider
-                      .getThemeComplementaryColor();
-                },
-              ),
-              shape: WidgetStateProperty.all<RoundedRectangleBorder>(
-                RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(18.0),
-                ),
-              ),
-            ),
+            style: customCardButtonStyle(appState),
             child: Padding(
               padding: const EdgeInsets.only(top: 8.0, left: 8.0, bottom: 6.0),
               child: Column(

--- a/chameleonultragui/lib/gui/page/read_card.dart
+++ b/chameleonultragui/lib/gui/page/read_card.dart
@@ -1,4 +1,5 @@
 import 'package:chameleonultragui/bridge/chameleon.dart';
+import 'package:chameleonultragui/gui/component/card_button.dart';
 import 'package:chameleonultragui/gui/component/mifare/classic.dart';
 import 'package:chameleonultragui/gui/component/error_message.dart';
 import 'package:chameleonultragui/gui/component/mifare/ultralight.dart';
@@ -315,6 +316,7 @@ class ReadCardPageState extends State<ReadCardPage> {
                             appState.changesMade();
                           }
                         },
+                        style: customCardButtonStyle(appState),
                         child: Text(localizations.read),
                       ),
                       if (hfInfo.uid != "") ...[
@@ -355,6 +357,7 @@ class ReadCardPageState extends State<ReadCardPage> {
                               },
                             );
                           },
+                          style: customCardButtonStyle(appState),
                           child: Text(localizations.save_only_uid),
                         ),
                       ],
@@ -424,6 +427,7 @@ class ReadCardPageState extends State<ReadCardPage> {
                             appState.changesMade();
                           }
                         },
+                        style: customCardButtonStyle(appState),
                         child: Text(localizations.read),
                       ),
                       if (lfInfo.uid != "") ...[
@@ -464,6 +468,7 @@ class ReadCardPageState extends State<ReadCardPage> {
                               },
                             );
                           },
+                          style: customCardButtonStyle(appState),
                           child: Text(localizations.save),
                         ),
                       ],

--- a/chameleonultragui/lib/gui/page/saved_cards.dart
+++ b/chameleonultragui/lib/gui/page/saved_cards.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:chameleonultragui/bridge/chameleon.dart';
+import 'package:chameleonultragui/gui/component/card_button.dart';
 import 'package:chameleonultragui/gui/component/saved_card.dart';
 import 'package:chameleonultragui/gui/menu/dictionary_edit.dart';
 import 'package:chameleonultragui/gui/menu/card_view.dart';
@@ -440,19 +441,7 @@ class SavedCardsPageState extends State<SavedCardsPage> {
                         }
                       }
                     },
-                    style: ButtonStyle(
-                      backgroundColor: WidgetStateProperty.resolveWith<Color>(
-                        (Set<WidgetState> states) {
-                          return appState.sharedPreferencesProvider
-                              .getThemeComplementaryColor();
-                        },
-                      ),
-                      shape: WidgetStateProperty.all<RoundedRectangleBorder>(
-                        RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(18.0),
-                        ),
-                      ),
-                    ),
+                    style: customCardButtonStyle(appState),
                     child: const Icon(Icons.add),
                   ),
                 )
@@ -629,19 +618,7 @@ class SavedCardsPageState extends State<SavedCardsPage> {
                         appState.changesMade();
                       }
                     },
-                    style: ButtonStyle(
-                      backgroundColor: WidgetStateProperty.resolveWith<Color>(
-                        (Set<WidgetState> states) {
-                          return appState.sharedPreferencesProvider
-                              .getThemeComplementaryColor();
-                        },
-                      ),
-                      shape: WidgetStateProperty.all<RoundedRectangleBorder>(
-                        RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(18.0),
-                        ),
-                      ),
-                    ),
+                    style: customCardButtonStyle(appState),
                     child: const Icon(Icons.add),
                   ),
                 )


### PR DESCRIPTION
I noticed that on the `Read Card` page, the button blends in with the background color of the parent element, making it difficult to distinguish.

<img width="1316" alt="截屏2025-03-08 下午11 22 29" src="https://github.com/user-attachments/assets/271ca0be-43e6-42ab-9829-5716aa515fa8" />

 In contrast, on the `Saved Cards` page, the button color and style look more aesthetically pleasing. 

<img width="1316" alt="截屏2025-03-08 下午11 21 27" src="https://github.com/user-attachments/assets/571ebf53-2782-45f7-ba95-3c580bf7450b" />

Therefore, I have extracted the relevant styles into a separate function and applied them to the `Read Card` page and related components.

<img width="1316" alt="截屏2025-03-08 下午11 21 17" src="https://github.com/user-attachments/assets/a9b6fea0-d9ae-494f-8f16-395da25cf0b7" />