### PR TITLE
fix: display error message with Logger

### DIFF
--- a/chameleonultragui/lib/helpers/open_collective.dart
+++ b/chameleonultragui/lib/helpers/open_collective.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'package:logger/logger.dart';
 
 Future<List<String>> fetchOpenCollectiveContributors() async {
   final Uri url = Uri.parse('https://api.opencollective.com/graphql/v2');
@@ -28,8 +29,9 @@ Future<List<String>> fetchOpenCollectiveContributors() async {
 
     return contributorsList;
   } catch (e) {
-    List<String> error = [e.toString()];
-    return error;
+    Logger log = Logger();
+    log.d(e.toString());
+    return [""];
   }
 }
 
@@ -44,6 +46,8 @@ Future<double> fetchOpenCollectiveBalance() async {
     final json = jsonDecode(response.body);
     return json["data"]["account"]["stats"]["balance"];
   } catch (e) {
+    Logger log = Logger();
+    log.d(e.toString());
     return 0;
   }
 }

--- a/chameleonultragui/lib/helpers/open_collective.dart
+++ b/chameleonultragui/lib/helpers/open_collective.dart
@@ -31,7 +31,7 @@ Future<List<String>> fetchOpenCollectiveContributors() async {
   } catch (e) {
     Logger log = Logger();
     log.d(e.toString());
-    return [""];
+    return ["(Failed to load contributors list, please try again later)"];
   }
 }
 


### PR DESCRIPTION
The GraphQL API provided by Open Collective is protected by Cloudflare, and some IPs from certain ISPs might be blocked, leading to access failures. The current default behavior when access fails is to display an error message, but this is unnecessary for ordinary users.
![IMG_1444](https://github.com/user-attachments/assets/9e7edd4f-221d-4423-bf54-50b5f71b6c80)


I have moved the display of related errors to the console.
<img width="912" alt="截屏2025-03-10 下午2 11 29" src="https://github.com/user-attachments/assets/23c914e9-2835-4b6c-bbc8-5ca74e92a996" />
<img width="948" alt="截屏2025-03-10 下午2 35 23" src="https://github.com/user-attachments/assets/a101da21-3fd6-4193-b934-41438e38cfef" />
