### PR TITLE
fix/improve static encrypted nonces detecion

### DIFF
--- a/chameleonultragui/lib/helpers/mifare_classic/general.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/general.dart
@@ -82,6 +82,18 @@ final gMifareClassicKeys = gMifareClassicKeysList
 
 Future<MifareClassicType> mfClassicGetType(
     ChameleonCommunicator communicator) async {
+  // Lee la info básica de la tarjeta
+  final tagInfo = await communicator.scan14443aTag();
+  final atqa = tagInfo.atqa;
+  final sak = tagInfo.sak;
+
+  // Detección automática para Mifare Classic 1K y Plus en modo 1K!
+  // SAK 0x08 y ATQA 0x0004: fuerza siempre a 1K aunque responda como 2K
+  if (atqa.length == 2 && atqa[0] == 0x00 && atqa[1] == 0x04 && sak == 0x08) {
+    return MifareClassicType.m1k;
+  }
+
+  // Detección estándar por bloques disponibles
   if ((await communicator.send14ARaw(Uint8List.fromList([0x60, 255]),
               checkResponseCrc: false))
           .length ==


### PR DESCRIPTION
# Pull Request: Attempted Improvement – Static Nonce Detection 

## Description

This pull request is an attempt to improve the `MifareClassicRecovery` class by enhancing the detection of static and pseudo-static encrypted nonces, and refining the key recovery process for MIFARE Classic cards and their clones (including Fudan variants).

A predefined list of known static nonce patterns has been included, and a detection mechanism has been implemented to automatically identify these patterns before initiating key recovery or attack attempts.  


> ⚠️ Please note: I am not an experienced contributor, and this is my best effort to improve the current functionality. I welcome all feedback, suggestions, or corrections.

---

## Changes Introduced

- Added a `staticEncryptedNonces` constant with a list of known static and pseudo-static nonce patterns (including common patterns from Fudan clones, accounting for endianness).
- Implemented a `checkForStaticEncryptedNonces()` method to evaluate selected blocks for these patterns.
- Updated `recoverKeys()` to perform early validation and gracefully abort if static nonces are detected.
- Improved logging and user-facing warning messages to better inform users about limitations due to static nonces.

---

**Feedback is very welcome. Thank you for your time and help!**
