### PR TITLE
feat: use macos-latest for iOS build

### DIFF
--- a/.github/workflows/publish-app.yml
+++ b/.github/workflows/publish-app.yml
@@ -153,7 +153,7 @@ jobs:
           app-store-connect builds submit-to-testflight $BUILD_ID || true
           app-store-connect beta-groups add-build $BUILD_ID --beta-group="Open beta testing" || true
   build-ios:
-    runs-on: macos-14
+    runs-on: macos-latest
     env:
       APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
       APP_STORE_CONNECT_KEY_IDENTIFIER: ${{ secrets.APP_STORE_CONNECT_KEY_IDENTIFIER }}


### PR DESCRIPTION
ITMS-90725: SDK version issue - This app was built with the iOS 18.2 SDK. Starting April 28, 2026, all iOS and iPadOS apps must be built with the iOS 26 SDK or later, included in Xcode 26 or later, in order to be uploaded to App Store Connect or submitted for distribution. 

I don't remember why macos-14 is selected here