### PR TITLE
Fix slot export for HF NTAG 216 tags

### DIFF
--- a/chameleonultragui/lib/l10n/app_en.arb
+++ b/chameleonultragui/lib/l10n/app_en.arb
@@ -224,6 +224,8 @@
   "save_to_file": "Save to file",
   "export_to_new_card": "Export to new card",
   "update_saved_card": "Update saved card",
+  "failed_to_export_slot": "Failed to export slot data.",
+  "exporting": "Exporting...",
   "must_be_valid_hex": "Must be valid HEX",
   "export_to_dictionary": "Export found keys",
   "enter_name_of_card": "Enter name of card",


### PR DESCRIPTION
#### Current Behavior
Clicking the download button in slot settings for an HF NTAG 216 slot silently fails — neither "Save to file", "Export to new card", nor "Update saved card" produce any result. This is caused by an unhandled exception during the 231 sequential page reads required for NTAG 216, which Flutter silently swallows, leaving the UI unresponsive with no feedback.

Issue: N/A

#### Changes
- Wrap NTAG/Ultralight page reads in try/catch; return null on failure so callers can handle the error gracefully
- Add error dialog ("Failed to export slot data.") on all three export buttons when the read fails
- Show a progress bar dialog (LinearProgressIndicator) during export, but only for Ultralight/NTAG tags where page reads are performed
- Read pages in batches of 16 instead of one at a time (~15x fewer operations), with automatic fallback to single-page reads if a batch fails
- Add localization strings: failed_to_export_slot, exporting

#### Breaking Changes
None