### PR TITLE
fix: switch to reader mode before T55xx write

### DIFF
--- a/chameleonultragui/lib/gui/page/write_card.dart
+++ b/chameleonultragui/lib/gui/page/write_card.dart
@@ -121,10 +121,15 @@ class WriteCardPageState extends State<WriteCardPage> {
   }
 
   Future<void> writeCard() async {
+    var appState = Provider.of<ChameleonGUIState>(context, listen: false);
     var scaffoldMessenger = ScaffoldMessenger.of(context);
     var localizations = AppLocalizations.of(context)!;
     SnackBar snackBar;
     updateProgress(0);
+
+    if (!await appState.communicator!.isReaderDeviceMode()) {
+      await appState.communicator!.setReaderDeviceMode(true);
+    }
 
     if (await helper!.writeData(card!, updateProgress)) {
       snackBar = SnackBar(


### PR DESCRIPTION
## Summary

Fix silent write failure on the Write Card page when the device is in emulator mode. `writeCard()` now switches the device to reader mode before invoking the write helper, mirroring the check already present in `detectMagicType()` and `readLFInfo()`.

## Motivation

Reproducible on macOS with a Chameleon Ultra over BLE or USB:

1. Put the device in emulator mode (e.g. use slot emulation for a previous session, or call `hw mode -e` from the CLI).
2. Open Write Card in the GUI, pick a saved T55xx-writable card (EM410X / HID Prox / Viking), supply the T5577 password.
3. Press "Write" with a fresh T5577 fob on the antenna.

Observed: the snackbar shows `magic_failed_write` with no further detail. Logging the Dart bridge reveals the firmware replies with `status = 0x66 = STATUS_DEVICE_MODE_ERROR` to every LF write/scan command: the firmware refuses because the device is still in tag-emulation mode, not in reader mode.

The write helper (`BaseT55XXCardHelper.writeData`) does not perform the mode switch, and neither does the caller `writeCard()`. The sister flows already do:

- `write_card.dart:68-70` (`detectMagicType`)
- `read_card.dart:123-124` (`readLFInfo`)

This PR copies the same two-line check into `writeCard()` so any T55xx write originating from the Write Card page works regardless of the device's previous mode.

## Changes

**`lib/gui/page/write_card.dart`** (5 lines):

```dart
Future<void> writeCard() async {
  var appState = Provider.of<ChameleonGUIState>(context, listen: false);
  var scaffoldMessenger = ScaffoldMessenger.of(context);
  var localizations = AppLocalizations.of(context)!;
  SnackBar snackBar;
  updateProgress(0);

  if (!await appState.communicator!.isReaderDeviceMode()) {
    await appState.communicator!.setReaderDeviceMode(true);
  }

  if (await helper!.writeData(card!, updateProgress)) {
    ...
```

## Testing

- `flutter analyze lib/gui/page/write_card.dart` clean
- `flutter build macos --debug` succeeds
- Reproduced the failure on main with device in tag mode, confirmed fix makes the write succeed:
  - EM410X → T5577: written and read back OK, reader accepts the fob
  - Any LF type (HID Prox / Viking) benefits from the same fix
