### PR TITLE
feat: add ioProx tag type support

### DIFF
--- a/chameleonultragui/lib/bridge/chameleon.dart
+++ b/chameleonultragui/lib/bridge/chameleon.dart
@@ -571,6 +571,16 @@ class ChameleonCommunicator {
     return VikingCard.fromBytes(resp.data);
   }
 
+  Future<IoProxCard?> readIoProx() async {
+    var resp = await sendCmd(ChameleonCommand.scanIoProxTag);
+
+    if (resp!.data.isEmpty) {
+      return null;
+    }
+
+    return IoProxCard.fromBytes(resp.data);
+  }
+
   Future<void> setEM410XEmulatorID(Uint8List uid) async {
     await sendCmd(ChameleonCommand.setEM410XemulatorID, data: uid);
   }
@@ -581,6 +591,10 @@ class ChameleonCommunicator {
 
   Future<void> setVikingEmulatorID(Uint8List uid) async {
     await sendCmd(ChameleonCommand.setVikingEmulatorID, data: uid);
+  }
+
+  Future<void> setIoProxEmulatorID(Uint8List uid) async {
+    await sendCmd(ChameleonCommand.setIoProxEmulatorID, data: uid);
   }
 
   Future<void> writeEM410XtoT55XX(
@@ -628,6 +642,20 @@ class ChameleonCommunicator {
     }
 
     await sendCmd(ChameleonCommand.writeVikingToT5577,
+        data: Uint8List.fromList([...uid, ...newKey, ...keys]));
+  }
+
+  Future<void> writeIoProxToT55XX(
+      Uint8List uid, Uint8List newKey, List<Uint8List> oldKeys) async {
+    List<int> keys = [];
+
+    keys.addAll(newKey);
+
+    for (var oldKey in oldKeys) {
+      keys.addAll(oldKey);
+    }
+
+    await sendCmd(ChameleonCommand.writeIoProxToT5577,
         data: Uint8List.fromList([...uid, ...newKey, ...keys]));
   }
 
@@ -961,6 +989,11 @@ class ChameleonCommunicator {
   Future<VikingCard> getVikingEmulatorID() async {
     return VikingCard.fromBytes(
         (await sendCmd(ChameleonCommand.getVikingEmulatorID))!.data);
+  }
+
+  Future<IoProxCard> getIoProxEmulatorID() async {
+    return IoProxCard.fromBytes(
+        (await sendCmd(ChameleonCommand.getIoProxEmulatorID))!.data);
   }
 
   Future<DeviceSettings> getDeviceSettings() async {

--- a/chameleonultragui/lib/gui/menu/dialogs/slot/edit.dart
+++ b/chameleonultragui/lib/gui/menu/dialogs/slot/edit.dart
@@ -93,6 +93,12 @@ class SlotEditMenuState extends State<SlotEditMenu> {
             await appState.communicator!.getVikingEmulatorID();
         uidController.text = bytesToHexSpace(vikingCard.uid);
       } catch (_) {}
+    } else if (selectedType! == TagType.ioProx) {
+      try {
+        IoProxCard ioProxCard =
+            await appState.communicator!.getIoProxEmulatorID();
+        uidController.text = bytesToHexSpace(ioProxCard.uid);
+      } catch (_) {}
     } else if (isMifareClassic(selectedType!) ||
         isMifareUltralight(selectedType!)) {
       try {
@@ -189,6 +195,9 @@ class SlotEditMenuState extends State<SlotEditMenu> {
         await appState.communicator!
             .setHIDProxEmulatorID(hexToBytes(hidCard.toString()));
       } catch (_) {}
+    } else if (selectedType! == TagType.ioProx) {
+      await appState.communicator!.setIoProxEmulatorID(
+          hexToBytes(uidController.text.replaceAll(' ', '')));
     } else if (isMifareClassic(selectedType!) ||
         isMifareUltralight(selectedType!)) {
       var cardData = CardData(

--- a/chameleonultragui/lib/gui/menu/dialogs/slot/export.dart
+++ b/chameleonultragui/lib/gui/menu/dialogs/slot/export.dart
@@ -59,6 +59,12 @@ class SlotExportMenuState extends State<SlotExportMenu> {
           name: widget.names.lf,
           tag: widget.slotTypes.lf,
         );
+      } else if (widget.slotTypes.lf == TagType.ioProx) {
+        return CardSave(
+          uid: (await appState.communicator!.getIoProxEmulatorID()).toString(),
+          name: widget.names.lf,
+          tag: widget.slotTypes.lf,
+        );
       }
     } else {
       CardData data = await appState.communicator!.mf1GetAntiCollData();

--- a/chameleonultragui/lib/gui/page/home.dart
+++ b/chameleonultragui/lib/gui/page/home.dart
@@ -53,8 +53,8 @@ class HomePageState extends State<HomePage> {
     // Checks that firmware supports all functions of current app
     // If not, prompt user to update firmware (as outdated firmware might break app)
 
-    int ultraCapability = ChameleonCommand.setVikingEmulatorID.value;
-    int liteCapability = ChameleonCommand.setVikingEmulatorID.value;
+    int ultraCapability = ChameleonCommand.setIoProxEmulatorID.value;
+    int liteCapability = ChameleonCommand.setIoProxEmulatorID.value;
 
     var appState = context.read<ChameleonGUIState>();
     List<int> capabilities;

--- a/chameleonultragui/lib/gui/page/read_card.dart
+++ b/chameleonultragui/lib/gui/page/read_card.dart
@@ -127,6 +127,7 @@ class ReadCardPageState extends State<ReadCardPage> {
     LFCard? card = await appState.communicator!.readEM410X();
     card ??= await appState.communicator!.readHIDProx();
     card ??= await appState.communicator!.readViking();
+    card ??= await appState.communicator!.readIoProx();
 
     if (card != null) {
       setState(() {

--- a/chameleonultragui/lib/gui/page/slot_manager.dart
+++ b/chameleonultragui/lib/gui/page/slot_manager.dart
@@ -202,6 +202,22 @@ class SlotManagerPageState extends State<SlotManagerPage> {
       await appState.communicator!.saveSlotData();
       appState.changesMade();
       refreshSlot();
+    } else if (card.tag == TagType.ioProx) {
+      close(context, card.name);
+      await appState.communicator!.setReaderDeviceMode(false);
+      await appState.communicator!
+          .enableSlot(gridPosition, TagFrequency.lf, true);
+      await appState.communicator!.activateSlot(gridPosition);
+      await appState.communicator!.setSlotType(gridPosition, card.tag);
+      await appState.communicator!.setDefaultDataToSlot(gridPosition, card.tag);
+      await appState.communicator!.setIoProxEmulatorID(hexToBytes(card.uid));
+      await appState.communicator!.setSlotTagName(
+          gridPosition,
+          (card.name.isEmpty) ? localizations.no_name : card.name,
+          TagFrequency.lf);
+      await appState.communicator!.saveSlotData();
+      appState.changesMade();
+      refreshSlot();
     } else if (isMifareUltralight(card.tag)) {
       close(context, card.name);
       setUploadState(0);

--- a/chameleonultragui/lib/helpers/definitions.dart
+++ b/chameleonultragui/lib/helpers/definitions.dart
@@ -83,6 +83,8 @@ enum ChameleonCommand {
   writeHIDProxToT5577(3003),
   scanVikingTag(3004),
   writeVikingToT5577(3005),
+  scanIoProxTag(3010),
+  writeIoProxToT5577(3011),
 
   mf1LoadBlockData(4000),
   mf1SetAntiCollision(4001),
@@ -136,7 +138,10 @@ enum ChameleonCommand {
   getHIDProxEmulatorID(5003),
 
   setVikingEmulatorID(5004),
-  getVikingEmulatorID(5005);
+  getVikingEmulatorID(5005),
+
+  setIoProxEmulatorID(5008),
+  getIoProxEmulatorID(5009);
 
   const ChameleonCommand(this.value);
   final int value;
@@ -151,6 +156,7 @@ enum TagType {
   em410XElectra(104),
   viking(170),
   hidProx(200),
+  ioProx(201),
   mifareMini(1000),
   mifare1K(1001),
   mifare2K(1002),
@@ -573,6 +579,21 @@ class VikingCard extends LFCard {
 
   VikingCard({
     super.type = TagType.viking,
+    required super.uid,
+  });
+}
+
+class IoProxCard extends LFCard {
+  factory IoProxCard.fromBytes(Uint8List bytes) {
+    return IoProxCard(uid: bytes);
+  }
+
+  factory IoProxCard.fromUID(String uid) {
+    return IoProxCard.fromBytes(hexToBytes(uid));
+  }
+
+  IoProxCard({
+    super.type = TagType.ioProx,
     required super.uid,
   });
 }

--- a/chameleonultragui/lib/helpers/general.dart
+++ b/chameleonultragui/lib/helpers/general.dart
@@ -165,6 +165,8 @@ String chameleonTagToString(TagType tag, AppLocalizations localizations) {
     return "HID Prox";
   } else if (tag == TagType.viking) {
     return "Viking";
+  } else if (tag == TagType.ioProx) {
+    return "ioProx";
   } else if (tag == TagType.ntag210) {
     return "NTAG210";
   } else if (tag == TagType.ntag212) {
@@ -449,7 +451,8 @@ List<TagType> getTagTypesByFrequency(TagFrequency frequency) {
       TagType.em410X64,
       TagType.em410XElectra,
       TagType.hidProx,
-      TagType.viking
+      TagType.viking,
+      TagType.ioProx
     ];
   }
 
@@ -543,6 +546,10 @@ LFCard getLFCardFromUID(TagType type, String uid) {
     return VikingCard.fromUID(uid);
   }
 
+  if (type == TagType.ioProx) {
+    return IoProxCard.fromUID(uid);
+  }
+
   return EM410XCard.fromUID(uid, type: type);
 }
 
@@ -555,6 +562,8 @@ int uidSizeForLfTag(TagType type) {
     return 5;
   } else if (type == TagType.viking) {
     return 4;
+  } else if (type == TagType.ioProx) {
+    return 16;
   }
 
   return 0;

--- a/chameleonultragui/lib/helpers/t55xx/write/base.dart
+++ b/chameleonultragui/lib/helpers/t55xx/write/base.dart
@@ -161,6 +161,11 @@ class BaseT55XXCardHelper extends AbstractWriteHelper {
           hexToBytes(newKey), [hexToBytes(currentKey), Uint8List(4)]);
       var newCard = await communicator.readViking();
       return newCard.toString() == card.uid;
+    } else if (card.tag == TagType.ioProx) {
+      await communicator.writeIoProxToT55XX(hexToBytes(card.uid),
+          hexToBytes(newKey), [hexToBytes(currentKey), Uint8List(4)]);
+      var newCard = await communicator.readIoProx();
+      return newCard.toString() == card.uid;
     }
 
     return false;

--- a/chameleonultragui/lib/helpers/write.dart
+++ b/chameleonultragui/lib/helpers/write.dart
@@ -61,7 +61,10 @@ abstract class AbstractWriteHelper {
       return BaseMifareUltralightWriteHelper(appState.communicator!);
     }
 
-    if (isEM410X(type) || type == TagType.hidProx || type == TagType.viking) {
+    if (isEM410X(type) ||
+        type == TagType.hidProx ||
+        type == TagType.viking ||
+        type == TagType.ioProx) {
       return BaseT55XXCardHelper(appState.communicator!);
     }
 


### PR DESCRIPTION
## Summary

Adds GUI support for the ioProx LF tag type. The firmware has full ioProx support (scan, emulate, T55xx write) but the GUI has never exposed it.

## Motivation

ioProx is a common LF credential (HID's FSK-based 26/64-bit format) already implemented in the Chameleon Ultra firmware: `TAG_TYPE_IOPROX = 201` plus six `DATA_CMD_IOPROX_*` commands. Without GUI wiring, users must drop to the Python CLI to provision ioProx slots, which is a friction point for anyone coming from a Flipper/Proxmark workflow.

## Changes

**`helpers/definitions.dart`**
- Add `TagType.ioProx(201)`
- Add `ChameleonCommand.scanIoProxTag(3010)`, `writeIoProxToT5577(3011)`, `setIoProxEmulatorID(5008)`, `getIoProxEmulatorID(5009)`
- New `IoProxCard extends LFCard` (modeled on `VikingCard`)

**`bridge/chameleon.dart`**
- `readIoProx`, `setIoProxEmulatorID`, `writeIoProxToT55XX`, `getIoProxEmulatorID`

**`helpers/general.dart`**
- Display name "ioProx", add to LF tag type list, `getLFCardFromUID` factory, `uidSizeForLfTag` = 16 bytes (raw 128-bit frame)

**`helpers/write.dart`, `helpers/t55xx/write/base.dart`**
- Route ioProx through the existing T55xx write helper with read-back verification

**`gui/page/slot_manager.dart`, `gui/menu/dialogs/slot/edit.dart`, `gui/menu/dialogs/slot/export.dart`, `gui/page/read_card.dart`**
- Branches to save an ioProx CardSave into a slot, load/save the emulator ID in the slot edit dialog, export the slot back to a CardSave, and include ioProx in the LF reader scan chain

**`gui/page/home.dart`**
- Bump the firmware capability gate from `setVikingEmulatorID` to `setIoProxEmulatorID`

## Testing

- `flutter analyze lib/` clean (no new issues)
- `flutter build macos --debug` succeeds
- No regressions on existing LF tag types (EM410x / HIDProx / Viking)

## Not included

- ioProx decode/compose helpers (`DATA_CMD_IOPROX_DECODE_RAW = 3012`, `DATA_CMD_IOPROX_COMPOSE_ID = 3013`) which would split the frame into FC/CN fields, following the HID Prox pattern. Shippable in a follow-up PR without breaking changes, since the underlying frame is already handled here as raw hex.

## Pattern

The implementation follows the `Viking` integration 1:1 (simplest existing LF tag with raw-hex UID). Same file touches, same else-if chain placement. UID size is the only difference (16 bytes vs Viking's 4).
