### PR TITLE
feat: add PAC/Stanley tag type support

### DIFF
--- a/chameleonultragui/lib/bridge/chameleon.dart
+++ b/chameleonultragui/lib/bridge/chameleon.dart
@@ -571,6 +571,16 @@ class ChameleonCommunicator {
     return VikingCard.fromBytes(resp.data);
   }
 
+  Future<PacCard?> readPac() async {
+    var resp = await sendCmd(ChameleonCommand.scanPacTag);
+
+    if (resp!.data.isEmpty) {
+      return null;
+    }
+
+    return PacCard.fromBytes(resp.data);
+  }
+
   Future<IoProxCard?> readIoProx() async {
     var resp = await sendCmd(ChameleonCommand.scanIoProxTag);
 
@@ -591,6 +601,10 @@ class ChameleonCommunicator {
 
   Future<void> setVikingEmulatorID(Uint8List uid) async {
     await sendCmd(ChameleonCommand.setVikingEmulatorID, data: uid);
+  }
+
+  Future<void> setPacEmulatorID(Uint8List uid) async {
+    await sendCmd(ChameleonCommand.setPacEmulatorID, data: uid);
   }
 
   Future<void> setIoProxEmulatorID(Uint8List uid) async {
@@ -642,6 +656,20 @@ class ChameleonCommunicator {
     }
 
     await sendCmd(ChameleonCommand.writeVikingToT5577,
+        data: Uint8List.fromList([...uid, ...newKey, ...keys]));
+  }
+
+  Future<void> writePacToT55XX(
+      Uint8List uid, Uint8List newKey, List<Uint8List> oldKeys) async {
+    List<int> keys = [];
+
+    keys.addAll(newKey);
+
+    for (var oldKey in oldKeys) {
+      keys.addAll(oldKey);
+    }
+
+    await sendCmd(ChameleonCommand.writePacToT5577,
         data: Uint8List.fromList([...uid, ...newKey, ...keys]));
   }
 
@@ -989,6 +1017,11 @@ class ChameleonCommunicator {
   Future<VikingCard> getVikingEmulatorID() async {
     return VikingCard.fromBytes(
         (await sendCmd(ChameleonCommand.getVikingEmulatorID))!.data);
+  }
+
+  Future<PacCard> getPacEmulatorID() async {
+    return PacCard.fromBytes(
+        (await sendCmd(ChameleonCommand.getPacEmulatorID))!.data);
   }
 
   Future<IoProxCard> getIoProxEmulatorID() async {

--- a/chameleonultragui/lib/gui/menu/dialogs/slot/edit.dart
+++ b/chameleonultragui/lib/gui/menu/dialogs/slot/edit.dart
@@ -93,6 +93,11 @@ class SlotEditMenuState extends State<SlotEditMenu> {
             await appState.communicator!.getVikingEmulatorID();
         uidController.text = bytesToHexSpace(vikingCard.uid);
       } catch (_) {}
+    } else if (selectedType! == TagType.pac) {
+      try {
+        PacCard pacCard = await appState.communicator!.getPacEmulatorID();
+        uidController.text = bytesToHexSpace(pacCard.uid);
+      } catch (_) {}
     } else if (selectedType! == TagType.ioProx) {
       try {
         IoProxCard ioProxCard =
@@ -195,6 +200,9 @@ class SlotEditMenuState extends State<SlotEditMenu> {
         await appState.communicator!
             .setHIDProxEmulatorID(hexToBytes(hidCard.toString()));
       } catch (_) {}
+    } else if (selectedType! == TagType.pac) {
+      await appState.communicator!.setPacEmulatorID(
+          hexToBytes(uidController.text.replaceAll(' ', '')));
     } else if (selectedType! == TagType.ioProx) {
       await appState.communicator!.setIoProxEmulatorID(
           hexToBytes(uidController.text.replaceAll(' ', '')));

--- a/chameleonultragui/lib/gui/menu/dialogs/slot/export.dart
+++ b/chameleonultragui/lib/gui/menu/dialogs/slot/export.dart
@@ -59,6 +59,12 @@ class SlotExportMenuState extends State<SlotExportMenu> {
           name: widget.names.lf,
           tag: widget.slotTypes.lf,
         );
+      } else if (widget.slotTypes.lf == TagType.pac) {
+        return CardSave(
+          uid: (await appState.communicator!.getPacEmulatorID()).toString(),
+          name: widget.names.lf,
+          tag: widget.slotTypes.lf,
+        );
       } else if (widget.slotTypes.lf == TagType.ioProx) {
         return CardSave(
           uid: (await appState.communicator!.getIoProxEmulatorID()).toString(),

--- a/chameleonultragui/lib/gui/page/read_card.dart
+++ b/chameleonultragui/lib/gui/page/read_card.dart
@@ -127,6 +127,7 @@ class ReadCardPageState extends State<ReadCardPage> {
     LFCard? card = await appState.communicator!.readEM410X();
     card ??= await appState.communicator!.readHIDProx();
     card ??= await appState.communicator!.readViking();
+    card ??= await appState.communicator!.readPac();
     card ??= await appState.communicator!.readIoProx();
 
     if (card != null) {

--- a/chameleonultragui/lib/gui/page/slot_manager.dart
+++ b/chameleonultragui/lib/gui/page/slot_manager.dart
@@ -202,6 +202,22 @@ class SlotManagerPageState extends State<SlotManagerPage> {
       await appState.communicator!.saveSlotData();
       appState.changesMade();
       refreshSlot();
+    } else if (card.tag == TagType.pac) {
+      close(context, card.name);
+      await appState.communicator!.setReaderDeviceMode(false);
+      await appState.communicator!
+          .enableSlot(gridPosition, TagFrequency.lf, true);
+      await appState.communicator!.activateSlot(gridPosition);
+      await appState.communicator!.setSlotType(gridPosition, card.tag);
+      await appState.communicator!.setDefaultDataToSlot(gridPosition, card.tag);
+      await appState.communicator!.setPacEmulatorID(hexToBytes(card.uid));
+      await appState.communicator!.setSlotTagName(
+          gridPosition,
+          (card.name.isEmpty) ? localizations.no_name : card.name,
+          TagFrequency.lf);
+      await appState.communicator!.saveSlotData();
+      appState.changesMade();
+      refreshSlot();
     } else if (card.tag == TagType.ioProx) {
       close(context, card.name);
       await appState.communicator!.setReaderDeviceMode(false);

--- a/chameleonultragui/lib/helpers/definitions.dart
+++ b/chameleonultragui/lib/helpers/definitions.dart
@@ -85,6 +85,8 @@ enum ChameleonCommand {
   writeVikingToT5577(3005),
   scanIoProxTag(3010),
   writeIoProxToT5577(3011),
+  scanPacTag(3014),
+  writePacToT5577(3015),
 
   mf1LoadBlockData(4000),
   mf1SetAntiCollision(4001),
@@ -140,6 +142,9 @@ enum ChameleonCommand {
   setVikingEmulatorID(5004),
   getVikingEmulatorID(5005),
 
+  setPacEmulatorID(5006),
+  getPacEmulatorID(5007),
+
   setIoProxEmulatorID(5008),
   getIoProxEmulatorID(5009);
 
@@ -154,6 +159,7 @@ enum TagType {
   em410X32(102),
   em410X64(103),
   em410XElectra(104),
+  pac(150),
   viking(170),
   hidProx(200),
   ioProx(201),
@@ -579,6 +585,21 @@ class VikingCard extends LFCard {
 
   VikingCard({
     super.type = TagType.viking,
+    required super.uid,
+  });
+}
+
+class PacCard extends LFCard {
+  factory PacCard.fromBytes(Uint8List bytes) {
+    return PacCard(uid: bytes);
+  }
+
+  factory PacCard.fromUID(String uid) {
+    return PacCard.fromBytes(hexToBytes(uid));
+  }
+
+  PacCard({
+    super.type = TagType.pac,
     required super.uid,
   });
 }

--- a/chameleonultragui/lib/helpers/general.dart
+++ b/chameleonultragui/lib/helpers/general.dart
@@ -165,6 +165,8 @@ String chameleonTagToString(TagType tag, AppLocalizations localizations) {
     return "HID Prox";
   } else if (tag == TagType.viking) {
     return "Viking";
+  } else if (tag == TagType.pac) {
+    return "PAC/Stanley";
   } else if (tag == TagType.ioProx) {
     return "ioProx";
   } else if (tag == TagType.ntag210) {
@@ -452,6 +454,7 @@ List<TagType> getTagTypesByFrequency(TagFrequency frequency) {
       TagType.em410XElectra,
       TagType.hidProx,
       TagType.viking,
+      TagType.pac,
       TagType.ioProx
     ];
   }
@@ -546,6 +549,10 @@ LFCard getLFCardFromUID(TagType type, String uid) {
     return VikingCard.fromUID(uid);
   }
 
+  if (type == TagType.pac) {
+    return PacCard.fromUID(uid);
+  }
+
   if (type == TagType.ioProx) {
     return IoProxCard.fromUID(uid);
   }
@@ -562,6 +569,8 @@ int uidSizeForLfTag(TagType type) {
     return 5;
   } else if (type == TagType.viking) {
     return 4;
+  } else if (type == TagType.pac) {
+    return 8;
   } else if (type == TagType.ioProx) {
     return 16;
   }

--- a/chameleonultragui/lib/helpers/t55xx/write/base.dart
+++ b/chameleonultragui/lib/helpers/t55xx/write/base.dart
@@ -161,6 +161,11 @@ class BaseT55XXCardHelper extends AbstractWriteHelper {
           hexToBytes(newKey), [hexToBytes(currentKey), Uint8List(4)]);
       var newCard = await communicator.readViking();
       return newCard.toString() == card.uid;
+    } else if (card.tag == TagType.pac) {
+      await communicator.writePacToT55XX(hexToBytes(card.uid),
+          hexToBytes(newKey), [hexToBytes(currentKey), Uint8List(4)]);
+      var newCard = await communicator.readPac();
+      return newCard.toString() == card.uid;
     } else if (card.tag == TagType.ioProx) {
       await communicator.writeIoProxToT55XX(hexToBytes(card.uid),
           hexToBytes(newKey), [hexToBytes(currentKey), Uint8List(4)]);

--- a/chameleonultragui/lib/helpers/write.dart
+++ b/chameleonultragui/lib/helpers/write.dart
@@ -64,6 +64,7 @@ abstract class AbstractWriteHelper {
     if (isEM410X(type) ||
         type == TagType.hidProx ||
         type == TagType.viking ||
+        type == TagType.pac ||
         type == TagType.ioProx) {
       return BaseT55XXCardHelper(appState.communicator!);
     }


### PR DESCRIPTION
## Summary

Adds GUI support for the PAC/Stanley LF tag type. The firmware has full PAC support (scan, emulate, T55xx write) but the GUI has never exposed it.

## Motivation

PAC/Stanley is a mainstream LF credential already implemented in the Chameleon Ultra firmware: `TAG_TYPE_PAC = 150` plus four `DATA_CMD_PAC_*` commands. Without GUI wiring, users must drop to the Python CLI to provision PAC slots.

## Changes

**`helpers/definitions.dart`**
- Add `TagType.pac(150)`
- Add `ChameleonCommand.scanPacTag(3014)`, `writePacToT5577(3015)`, `setPacEmulatorID(5006)`, `getPacEmulatorID(5007)`
- New `PacCard extends LFCard` (modeled on `VikingCard`)

**`bridge/chameleon.dart`**
- `readPac`, `setPacEmulatorID`, `writePacToT55XX`, `getPacEmulatorID`

**`helpers/general.dart`**
- Display name "PAC/Stanley" (matches firmware CLI), add to LF tag type list, `getLFCardFromUID` factory, `uidSizeForLfTag` = 8 bytes

**`helpers/write.dart`, `helpers/t55xx/write/base.dart`**
- Route PAC through the existing T55xx write helper with read-back verification

**`gui/page/slot_manager.dart`, `gui/menu/dialogs/slot/edit.dart`, `gui/menu/dialogs/slot/export.dart`, `gui/page/read_card.dart`**
- Branches to save a PAC CardSave into a slot, load/save the emulator ID in the slot edit dialog, export the slot back to a CardSave, and include PAC in the LF reader scan chain

**`gui/page/home.dart`**
- Bump the firmware capability gate from `setVikingEmulatorID` to `setPacEmulatorID`

## Testing

- `flutter analyze lib/` clean (no new issues)
- `flutter build macos --debug` succeeds
- No regressions on existing LF tag types (EM410x / HIDProx / Viking)

## Pattern

The implementation follows the `Viking` integration 1:1 (simplest existing LF tag with raw-hex UID). Same file touches, same else-if chain placement.