### PR TITLE
feat: add IDTECK PSK1 tag type support

### DIFF
--- a/chameleonultragui/lib/bridge/chameleon.dart
+++ b/chameleonultragui/lib/bridge/chameleon.dart
@@ -597,6 +597,10 @@ class ChameleonCommunicator {
     await sendCmd(ChameleonCommand.setIoProxEmulatorID, data: uid);
   }
 
+  Future<void> setIdteckEmulatorID(Uint8List uid) async {
+    await sendCmd(ChameleonCommand.setIdteckEmulatorID, data: uid);
+  }
+
   Future<void> writeEM410XtoT55XX(
       Uint8List uid, Uint8List newKey, List<Uint8List> oldKeys) async {
     List<int> keys = [];
@@ -656,6 +660,20 @@ class ChameleonCommunicator {
     }
 
     await sendCmd(ChameleonCommand.writeIoProxToT5577,
+        data: Uint8List.fromList([...uid, ...newKey, ...keys]));
+  }
+
+  Future<void> writeIdteckToT55XX(
+      Uint8List uid, Uint8List newKey, List<Uint8List> oldKeys) async {
+    List<int> keys = [];
+
+    keys.addAll(newKey);
+
+    for (var oldKey in oldKeys) {
+      keys.addAll(oldKey);
+    }
+
+    await sendCmd(ChameleonCommand.writeIdteckToT5577,
         data: Uint8List.fromList([...uid, ...newKey, ...keys]));
   }
 
@@ -994,6 +1012,11 @@ class ChameleonCommunicator {
   Future<IoProxCard> getIoProxEmulatorID() async {
     return IoProxCard.fromBytes(
         (await sendCmd(ChameleonCommand.getIoProxEmulatorID))!.data);
+  }
+
+  Future<IdteckCard> getIdteckEmulatorID() async {
+    return IdteckCard.fromBytes(
+        (await sendCmd(ChameleonCommand.getIdteckEmulatorID))!.data);
   }
 
   Future<DeviceSettings> getDeviceSettings() async {

--- a/chameleonultragui/lib/gui/menu/dialogs/slot/edit.dart
+++ b/chameleonultragui/lib/gui/menu/dialogs/slot/edit.dart
@@ -99,6 +99,12 @@ class SlotEditMenuState extends State<SlotEditMenu> {
             await appState.communicator!.getIoProxEmulatorID();
         uidController.text = bytesToHexSpace(ioProxCard.uid);
       } catch (_) {}
+    } else if (selectedType! == TagType.idteck) {
+      try {
+        IdteckCard idteckCard =
+            await appState.communicator!.getIdteckEmulatorID();
+        uidController.text = bytesToHexSpace(idteckCard.uid);
+      } catch (_) {}
     } else if (isMifareClassic(selectedType!) ||
         isMifareUltralight(selectedType!)) {
       try {
@@ -197,6 +203,9 @@ class SlotEditMenuState extends State<SlotEditMenu> {
       } catch (_) {}
     } else if (selectedType! == TagType.ioProx) {
       await appState.communicator!.setIoProxEmulatorID(
+          hexToBytes(uidController.text.replaceAll(' ', '')));
+    } else if (selectedType! == TagType.idteck) {
+      await appState.communicator!.setIdteckEmulatorID(
           hexToBytes(uidController.text.replaceAll(' ', '')));
     } else if (isMifareClassic(selectedType!) ||
         isMifareUltralight(selectedType!)) {

--- a/chameleonultragui/lib/gui/menu/dialogs/slot/export.dart
+++ b/chameleonultragui/lib/gui/menu/dialogs/slot/export.dart
@@ -65,6 +65,12 @@ class SlotExportMenuState extends State<SlotExportMenu> {
           name: widget.names.lf,
           tag: widget.slotTypes.lf,
         );
+      } else if (widget.slotTypes.lf == TagType.idteck) {
+        return CardSave(
+          uid: (await appState.communicator!.getIdteckEmulatorID()).toString(),
+          name: widget.names.lf,
+          tag: widget.slotTypes.lf,
+        );
       }
     } else {
       CardData data = await appState.communicator!.mf1GetAntiCollData();

--- a/chameleonultragui/lib/gui/page/home.dart
+++ b/chameleonultragui/lib/gui/page/home.dart
@@ -53,8 +53,8 @@ class HomePageState extends State<HomePage> {
     // Checks that firmware supports all functions of current app
     // If not, prompt user to update firmware (as outdated firmware might break app)
 
-    int ultraCapability = ChameleonCommand.setIoProxEmulatorID.value;
-    int liteCapability = ChameleonCommand.setIoProxEmulatorID.value;
+    int ultraCapability = ChameleonCommand.setIdteckEmulatorID.value;
+    int liteCapability = ChameleonCommand.setIdteckEmulatorID.value;
 
     var appState = context.read<ChameleonGUIState>();
     List<int> capabilities;

--- a/chameleonultragui/lib/gui/page/read_card.dart
+++ b/chameleonultragui/lib/gui/page/read_card.dart
@@ -129,6 +129,7 @@ class ReadCardPageState extends State<ReadCardPage> {
     card ??= await appState.communicator!.readViking();
     card ??= await appState.communicator!.readIoProx();
 
+
     if (card != null) {
       setState(() {
         lfInfo.card = card;

--- a/chameleonultragui/lib/gui/page/slot_manager.dart
+++ b/chameleonultragui/lib/gui/page/slot_manager.dart
@@ -218,6 +218,22 @@ class SlotManagerPageState extends State<SlotManagerPage> {
       await appState.communicator!.saveSlotData();
       appState.changesMade();
       refreshSlot();
+    } else if (card.tag == TagType.idteck) {
+      close(context, card.name);
+      await appState.communicator!.setReaderDeviceMode(false);
+      await appState.communicator!
+          .enableSlot(gridPosition, TagFrequency.lf, true);
+      await appState.communicator!.activateSlot(gridPosition);
+      await appState.communicator!.setSlotType(gridPosition, card.tag);
+      await appState.communicator!.setDefaultDataToSlot(gridPosition, card.tag);
+      await appState.communicator!.setIdteckEmulatorID(hexToBytes(card.uid));
+      await appState.communicator!.setSlotTagName(
+          gridPosition,
+          (card.name.isEmpty) ? localizations.no_name : card.name,
+          TagFrequency.lf);
+      await appState.communicator!.saveSlotData();
+      appState.changesMade();
+      refreshSlot();
     } else if (isMifareUltralight(card.tag)) {
       close(context, card.name);
       setUploadState(0);

--- a/chameleonultragui/lib/helpers/definitions.dart
+++ b/chameleonultragui/lib/helpers/definitions.dart
@@ -85,6 +85,7 @@ enum ChameleonCommand {
   writeVikingToT5577(3005),
   scanIoProxTag(3010),
   writeIoProxToT5577(3011),
+  writeIdteckToT5577(3017),
 
   mf1LoadBlockData(4000),
   mf1SetAntiCollision(4001),
@@ -141,7 +142,10 @@ enum ChameleonCommand {
   getVikingEmulatorID(5005),
 
   setIoProxEmulatorID(5008),
-  getIoProxEmulatorID(5009);
+  getIoProxEmulatorID(5009),
+
+  setIdteckEmulatorID(5010),
+  getIdteckEmulatorID(5011);
 
   const ChameleonCommand(this.value);
   final int value;
@@ -157,6 +161,7 @@ enum TagType {
   viking(170),
   hidProx(200),
   ioProx(201),
+  idteck(310),
   mifareMini(1000),
   mifare1K(1001),
   mifare2K(1002),
@@ -594,6 +599,21 @@ class IoProxCard extends LFCard {
 
   IoProxCard({
     super.type = TagType.ioProx,
+    required super.uid,
+  });
+}
+
+class IdteckCard extends LFCard {
+  factory IdteckCard.fromBytes(Uint8List bytes) {
+    return IdteckCard(uid: bytes);
+  }
+
+  factory IdteckCard.fromUID(String uid) {
+    return IdteckCard.fromBytes(hexToBytes(uid));
+  }
+
+  IdteckCard({
+    super.type = TagType.idteck,
     required super.uid,
   });
 }

--- a/chameleonultragui/lib/helpers/general.dart
+++ b/chameleonultragui/lib/helpers/general.dart
@@ -167,6 +167,8 @@ String chameleonTagToString(TagType tag, AppLocalizations localizations) {
     return "Viking";
   } else if (tag == TagType.ioProx) {
     return "ioProx";
+  } else if (tag == TagType.idteck) {
+    return "IDTECK";
   } else if (tag == TagType.ntag210) {
     return "NTAG210";
   } else if (tag == TagType.ntag212) {
@@ -452,7 +454,8 @@ List<TagType> getTagTypesByFrequency(TagFrequency frequency) {
       TagType.em410XElectra,
       TagType.hidProx,
       TagType.viking,
-      TagType.ioProx
+      TagType.ioProx,
+      TagType.idteck
     ];
   }
 
@@ -550,6 +553,10 @@ LFCard getLFCardFromUID(TagType type, String uid) {
     return IoProxCard.fromUID(uid);
   }
 
+  if (type == TagType.idteck) {
+    return IdteckCard.fromUID(uid);
+  }
+
   return EM410XCard.fromUID(uid, type: type);
 }
 
@@ -564,6 +571,8 @@ int uidSizeForLfTag(TagType type) {
     return 4;
   } else if (type == TagType.ioProx) {
     return 16;
+  } else if (type == TagType.idteck) {
+    return 8;
   }
 
   return 0;

--- a/chameleonultragui/lib/helpers/t55xx/write/base.dart
+++ b/chameleonultragui/lib/helpers/t55xx/write/base.dart
@@ -166,6 +166,14 @@ class BaseT55XXCardHelper extends AbstractWriteHelper {
           hexToBytes(newKey), [hexToBytes(currentKey), Uint8List(4)]);
       var newCard = await communicator.readIoProx();
       return newCard.toString() == card.uid;
+    } else if (card.tag == TagType.idteck) {
+      await communicator.writeIdteckToT55XX(hexToBytes(card.uid),
+          hexToBytes(newKey), [hexToBytes(currentKey), Uint8List(4)]);
+      // IDTECK read is not implemented in the firmware (PSK demodulation
+      // on the envelope-only tag-emulation ADC path is a follow-up), so we
+      // cannot read back the tag for verification. Assume the T55xx write
+      // succeeded if the firmware did not raise an error.
+      return true;
     }
 
     return false;

--- a/chameleonultragui/lib/helpers/write.dart
+++ b/chameleonultragui/lib/helpers/write.dart
@@ -64,7 +64,8 @@ abstract class AbstractWriteHelper {
     if (isEM410X(type) ||
         type == TagType.hidProx ||
         type == TagType.viking ||
-        type == TagType.ioProx) {
+        type == TagType.ioProx ||
+        type == TagType.idteck) {
       return BaseT55XXCardHelper(appState.communicator!);
     }
 


### PR DESCRIPTION
## Summary

Adds GUI support for the IDTECK PSK1 LF tag type, mirroring the firmware implementation from RfidResearchGroup/ChameleonUltra#407. Lets users save, emulate, and T55xx-clone IDTECK cards directly from the app.

## Motivation

The firmware supports IDTECK emulation and T55xx writing, but the GUI has no knowledge of the `TAG_TYPE_IDTECK = 310` tag type nor of the three new `DATA_CMD_IDTECK_*` command IDs. Slots provisioned as IDTECK via CLI currently render as "unknown" in the slot manager, and there is no way to save an IDTECK card from a CardSave dump.

## Changes

**`helpers/definitions.dart`**
- Add `TagType.idteck(310)`
- Add `ChameleonCommand.writeIdteckToT5577(3017)`, `setIdteckEmulatorID(5010)`, `getIdteckEmulatorID(5011)`
- New `IdteckCard extends LFCard` (modeled on `VikingCard`)

**`bridge/chameleon.dart`**
- `setIdteckEmulatorID`, `writeIdteckToT55XX`, `getIdteckEmulatorID`
- No `readIdteck` — PSK demodulation is not implemented in the firmware yet

**`helpers/general.dart`**
- Display name "IDTECK", add to LF tag type list, `getLFCardFromUID` factory, `uidSizeForLfTag` = 8 bytes (preamble + payload)

**`helpers/write.dart`, `helpers/t55xx/write/base.dart`**
- Route IDTECK through the existing T55xx write helper (no read-back verification since `readIdteck` does not exist)

**`gui/page/slot_manager.dart`, `gui/menu/dialogs/slot/edit.dart`, `gui/menu/dialogs/slot/export.dart`**
- Branches to save an IDTECK CardSave into a slot, load/save the emulator ID in the slot edit dialog, and export the slot back to a CardSave

**`gui/page/home.dart`**
- Bump the firmware capability gate from `setVikingEmulatorID` to `setIdteckEmulatorID`, so users on older firmware get the "please update" prompt

## Dependencies

This PR depends on firmware PR RfidResearchGroup/ChameleonUltra#407. Merging before that firmware ships will cause the capability check to fail against all currently-released firmware builds.

## Testing

- `flutter analyze lib/` clean (no new issues)
- `flutter build macos --debug` succeeds
- Tested live against a Chameleon Ultra running the firmware branch from #407, BLE and USB:
  - Slot with `TAG_TYPE_IDTECK` renders as "IDTECK" (was "unknown")
  - Loading a saved IDTECK card into a slot writes the emulator ID and the slot emulates correctly against a real IDTECK reader
  - Editing an IDTECK slot round-trips the frame through get/set
  - Exporting a slot to a CardSave preserves the frame
  - **T5577 clone via the Write Card flow succeeds end-to-end**: frame is programmed on a blank T5577, and the resulting fob is accepted by the reader
- No regressions on EM410x / HIDProx / Viking slots

Note: the Write Card flow requires the sibling one-line fix in a parallel PR (`fix: switch to reader mode before T55xx write`) to work correctly when the device starts in tag-emulation mode. That fix is a pre-existing bug unrelated to IDTECK but affects every T55xx write path including this one.

## Not included

- `readIdteck()` — PSK1 demodulation on `LF_OA_OUT` is feasible but out of scope (firmware DSP work). Tracked as future firmware roadmap in the #407 description.
- Parsed format fields (facility code / card number) — the frame is exposed as raw 8-byte hex, following the Viking model. IDTECK sub-formats can be layered on later without breaking changes.

## Pattern

The implementation follows the `Viking` integration 1:1 (simplest existing LF tag with raw-hex UID). Same file touches, same else-if chain placement.