### PR TITLE
fix: update validKeys after writing sector trailer in Gen2 write

### DIFF
--- a/chameleonultragui/lib/helpers/mifare_classic/write/gen2.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/write/gen2.dart
@@ -132,6 +132,12 @@ class MifareClassicGen2WriteHelper extends BaseMifareClassicWriteHelper {
         cleanSectors[sector] = await writeBlockModifier(
             card, block, data[block],
             tryBothKeys: true);
+        if (cleanSectors[sector]) {
+          // Update keys to match the newly written trailer,
+          // so subsequent data block writes use the correct keys.
+          recovery.validKeys[sector] = data[block].sublist(0, 6);
+          recovery.validKeys[40 + sector] = data[block].sublist(10, 16);
+        }
       }
     }
 


### PR DESCRIPTION
After writing a sector trailer, the card's keys may have changed, but recovery.validKeys still held the old keys. Subsequent data block writes would then fail authentication. Sync validKeys from the dump's trailer data immediately after a successful trailer write.