### PR TITLE
Extract wake time strings to localizations

### DIFF
--- a/chameleonultragui/lib/gui/menu/dialogs/chameleon_settings.dart
+++ b/chameleonultragui/lib/gui/menu/dialogs/chameleon_settings.dart
@@ -182,7 +182,7 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                     ...(settings.wakeTimeSeconds != null)
                         ? [
                             const SizedBox(height: 10),
-                            const Text("Wake time after button press (s):"),
+                            Text(localizations.wake_time_after_button_press),
                             const SizedBox(height: 10),
                             Form(
                                 key: wakeTimeFormKey,
@@ -205,8 +205,8 @@ class ChameleonSettingsState extends State<ChameleonSettings> {
                                             FilteringTextInputFormatter
                                                 .digitsOnly
                                           ],
-                                          decoration: const InputDecoration(
-                                            labelText: "Wake time",
+                                          decoration: InputDecoration(
+                                            labelText: localizations.wake_time,
                                             hintText: "5-60",
                                           )),
                                     ),

--- a/chameleonultragui/lib/l10n/app_en.arb
+++ b/chameleonultragui/lib/l10n/app_en.arb
@@ -114,6 +114,8 @@
   "flash_via_dfu": "Flash latest FW via DFU",
   "flash_zip_dfu": "Flash .zip FW via DFU",
   "animations": "Animations",
+  "wake_time_after_button_press": "Wake time after button press (s):",
+  "wake_time": "Wake time",
   "button_config": "Button config",
   "button_x": "{x} button",
   "long_press": "Long press",


### PR DESCRIPTION
## Summary

- Add `wake_time_after_button_press` and `wake_time` keys to `app_en.arb`
- Replace the two hardcoded strings in `chameleon_settings.dart` with `localizations.*` references
- Remove `const` from the affected `Text` and `InputDecoration` widgets (required since localizations are runtime values)

The section heading *"Wake time after button press (s):"* and the input label *"Wake time"* were the only remaining hardcoded strings in the device settings dialog. All surrounding strings already used localizations.

## Test plan

- [ ] Open Device Settings dialog on a connected Chameleon device that exposes wake time (non-null `wakeTimeSeconds`)
- [ ] Confirm *"Wake time after button press (s):"* heading and *"Wake time"* input label render correctly in English
- [ ] Switch app language and verify the strings follow the selected locale (once translators add the new keys to other ARB files)
- [ ] Run `flutter gen-l10n` and confirm no generation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)