### PR TITLE
fix: correctly export ev1 as bin when on read page

### DIFF
--- a/chameleonultragui/lib/gui/component/mifare/classic.dart
+++ b/chameleonultragui/lib/gui/component/mifare/classic.dart
@@ -50,26 +50,19 @@ class CardReaderState extends State<MifareClassicHelper> {
   Future<void> saveCard({bool bin = false, bool skipDump = false}) async {
     var appState = Provider.of<ChameleonGUIState>(context, listen: false);
 
-    List<int> cardDump = [];
     var localizations = AppLocalizations.of(context)!;
+    Uint8List cardDump = Uint8List(0);
     if (!skipDump) {
-      for (var sector = 0;
-          sector < mfClassicGetSectorCount(widget.mfcInfo.type);
-          sector++) {
-        for (var block = 0;
-            block < mfClassicGetBlockCountBySector(sector);
-            block++) {
-          cardDump.addAll(widget.mfcInfo.recovery!
-              .cardData[block + mfClassicGetFirstBlockCountBySector(sector)]);
-        }
-      }
+      cardDump = mfClassicGetExportBytes(
+          widget.mfcInfo.type, widget.mfcInfo.recovery!.cardData,
+          isEV1: widget.mfcInfo.isEV1);
     }
 
     if (bin) {
       await FilePicker.saveFile(
         dialogTitle: '${localizations.output_file}:',
         fileName: '${widget.hfInfo.uid.replaceAll(" ", "")}.bin',
-        bytes: Uint8List.fromList(cardDump),
+        bytes: cardDump,
       );
     } else {
       var tags = appState.sharedPreferencesProvider.getCards();

--- a/chameleonultragui/lib/helpers/general.dart
+++ b/chameleonultragui/lib/helpers/general.dart
@@ -377,20 +377,44 @@ AnimationSetting getAnimationModeType(int value) {
 Future<void> saveTag(CardSave tag, BuildContext context, bool bin) async {
   var localizations = AppLocalizations.of(context)!;
   if (bin) {
-    List<int> tagDump = [];
-    for (var block in tag.data) {
-      tagDump.addAll(block);
+    Uint8List tagDump;
+    if (isMifareClassic(tag.tag)) {
+      tagDump = mfClassicGetExportBytes(
+          chameleonTagTypeGetMfClassicType(tag.tag), tag.data,
+          isEV1: chameleonTagSaveCheckForMifareClassicEV1(tag));
+    } else {
+      List<int> dump = [];
+      for (var block in tag.data) {
+        dump.addAll(block);
+      }
+      tagDump = Uint8List.fromList(dump);
     }
     await FilePicker.saveFile(
       dialogTitle: '${localizations.output_file}:',
       fileName: '${tag.name}.bin',
-      bytes: Uint8List.fromList(tagDump),
+      bytes: tagDump,
     );
   } else {
+    var exportTag = tag;
+    if (isMifareClassic(tag.tag)) {
+      exportTag = CardSave(
+          id: tag.id,
+          uid: tag.uid,
+          sak: tag.sak,
+          atqa: tag.atqa,
+          ats: tag.ats,
+          name: tag.name,
+          tag: tag.tag,
+          data: mfClassicGetExportBlocks(
+              chameleonTagTypeGetMfClassicType(tag.tag), tag.data,
+              isEV1: chameleonTagSaveCheckForMifareClassicEV1(tag)),
+          extraData: tag.extraData,
+          color: tag.color);
+    }
     await FilePicker.saveFile(
       dialogTitle: '${localizations.output_file}:',
       fileName: '${tag.name}.json',
-      bytes: const Utf8Encoder().convert(tag.toJson()),
+      bytes: const Utf8Encoder().convert(exportTag.toJson()),
     );
   }
 }
@@ -458,6 +482,8 @@ TagType getTagTypeByDumpSize(int size) {
     case 1024:
       return TagType.mifare1K;
     case 1088: // EV1
+    case 1152: // EV1
+      return TagType.mifare1K;
     case 2048:
       return TagType.mifare2K;
     case 4096:

--- a/chameleonultragui/lib/helpers/mifare_classic/general.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/general.dart
@@ -293,9 +293,40 @@ MifareClassicType chameleonTagTypeGetMfClassicType(TagType type) {
 }
 
 bool chameleonTagSaveCheckForMifareClassicEV1(CardSave tag) {
-  return tag.tag == TagType.mifare1K &&
-      tag.data.length >= 71 &&
-      tag.data[71].isNotEmpty;
+  if (tag.tag != TagType.mifare1K || tag.data.length <= 64) {
+    return false;
+  }
+
+  for (var block = 64; block < 72 && block < tag.data.length; block++) {
+    if (tag.data[block].isNotEmpty) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+List<Uint8List> mfClassicGetExportBlocks(
+    MifareClassicType type, List<Uint8List> data,
+    {bool isEV1 = false}) {
+  final blockCount = mfClassicGetBlockCount(type, isEV1: isEV1);
+  return List.generate(blockCount, (block) {
+    if (data.length > block && data[block].length == 16) {
+      return Uint8List.fromList(data[block]);
+    }
+
+    return Uint8List(16);
+  });
+}
+
+Uint8List mfClassicGetExportBytes(MifareClassicType type, List<Uint8List> data,
+    {bool isEV1 = false}) {
+  final output = <int>[];
+  for (var block in mfClassicGetExportBlocks(type, data, isEV1: isEV1)) {
+    output.addAll(block);
+  }
+
+  return Uint8List.fromList(output);
 }
 
 bool isMifareClassic(TagType type) {

--- a/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
@@ -612,7 +612,8 @@ class MifareClassicRecovery {
               blockData;
 
           dumpProgress = (block + mfClassicGetFirstBlockCountBySector(sector)) /
-              (mfClassicGetBlockCount(mifareClassicType));
+              (mfClassicGetBlockCount(mifareClassicType,
+                  isEV1: isMifareClassicEV1));
 
           update();
 


### PR DESCRIPTION
Ensure to always correctly export EV1 bins and json dumps.

Original report:

> Hey all. I've noticed that when making a dump of Mifare 1k EV1, if I decde to "save bin" right after pressing dump, it will create a 1024-byte dump. However, if I just press "save" (instead of "save bin"), it will save the card in my local collection. Later on, if I go to my saved cards collections and proceed to export it, the bin and json include the signature sectors.