### PR TITLE
feat: press and hold followed by drag to bulk toggle sectors

### DIFF
--- a/chameleonultragui/lib/gui/component/key_check_marks.dart
+++ b/chameleonultragui/lib/gui/component/key_check_marks.dart
@@ -31,6 +31,81 @@ class KeyCheckMarks extends StatefulWidget {
 }
 
 class _KeyCheckMarksState extends State<KeyCheckMarks> {
+  final Map<int, GlobalKey> _checkmarkKeys = {};
+  final Set<int> _draggedCheckmarks = {};
+  ChameleonKeyCheckmark? _dragValue;
+
+  GlobalKey _checkmarkKey(int index) {
+    return _checkmarkKeys.putIfAbsent(index, () => GlobalKey());
+  }
+
+  void _startCheckmarkDrag(int index) {
+    switch (widget.checkMarks[index]) {
+      case ChameleonKeyCheckmark.none:
+        _dragValue = ChameleonKeyCheckmark.disabled;
+        break;
+      case ChameleonKeyCheckmark.disabled:
+        _dragValue = ChameleonKeyCheckmark.none;
+        break;
+      case ChameleonKeyCheckmark.found:
+      case ChameleonKeyCheckmark.checking:
+        _dragValue = null;
+        break;
+    }
+
+    _draggedCheckmarks.clear();
+    _applyDragValue(index);
+  }
+
+  void _applyDragValue(int index) {
+    final dragValue = _dragValue;
+    if (dragValue == null || !_draggedCheckmarks.add(index)) {
+      return;
+    }
+
+    final currentValue = widget.checkMarks[index];
+    if ((currentValue == ChameleonKeyCheckmark.none &&
+            dragValue == ChameleonKeyCheckmark.disabled) ||
+        (currentValue == ChameleonKeyCheckmark.disabled &&
+            dragValue == ChameleonKeyCheckmark.none)) {
+      widget.onCheckmarkChanged?.call(index, dragValue);
+    }
+  }
+
+  void _continueCheckmarkDrag(Offset globalPosition) {
+    for (final entry in _checkmarkKeys.entries) {
+      final renderObject = entry.value.currentContext?.findRenderObject();
+      if (renderObject is! RenderBox || !renderObject.attached) {
+        continue;
+      }
+
+      final topLeft = renderObject.localToGlobal(Offset.zero);
+      final bottomRight = renderObject
+          .localToGlobal(renderObject.size.bottomRight(Offset.zero));
+      if (Rect.fromPoints(topLeft, bottomRight).contains(globalPosition)) {
+        _applyDragValue(entry.key);
+        return;
+      }
+    }
+  }
+
+  void _endCheckmarkDrag() {
+    _dragValue = null;
+    _draggedCheckmarks.clear();
+  }
+
+  Widget _buildDraggableIcon(int index, IconData icon) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onLongPressStart: (_) => _startCheckmarkDrag(index),
+      onLongPressMoveUpdate: (details) =>
+          _continueCheckmarkDrag(details.globalPosition),
+      onLongPressEnd: (_) => _endCheckmarkDrag(),
+      onLongPressCancel: _endCheckmarkDrag,
+      child: Icon(icon, color: Colors.red),
+    );
+  }
+
   Widget buildCheckmark(BuildContext context, int index,
       {bool tooltipBelow = true}) {
     var checkMark = widget.checkMarks[index];
@@ -51,10 +126,7 @@ class _KeyCheckMarksState extends State<KeyCheckMarks> {
         return IconButton(
           padding: EdgeInsets.zero,
           constraints: const BoxConstraints(),
-          icon: const Icon(
-            Icons.close,
-            color: Colors.red,
-          ),
+          icon: _buildDraggableIcon(index, Icons.close),
           tooltip: localizations.skip_recovery,
           onPressed: widget.onCheckmarkChanged != null
               ? () {
@@ -67,10 +139,7 @@ class _KeyCheckMarksState extends State<KeyCheckMarks> {
         return IconButton(
           padding: EdgeInsets.zero,
           constraints: const BoxConstraints(),
-          icon: const Icon(
-            Icons.cancel,
-            color: Colors.red,
-          ),
+          icon: _buildDraggableIcon(index, Icons.cancel),
           tooltip: localizations.resume_recovery,
           onPressed: widget.onCheckmarkChanged != null
               ? () {
@@ -144,6 +213,7 @@ class _KeyCheckMarksState extends State<KeyCheckMarks> {
               (index) => Padding(
                 padding: const EdgeInsets.all(2),
                 child: SizedBox(
+                  key: _checkmarkKey(checkmarkIndex + index),
                   width: widget.checkmarkSize,
                   height: widget.checkmarkSize,
                   child: buildCheckmark(context, checkmarkIndex + index,
@@ -168,6 +238,7 @@ class _KeyCheckMarksState extends State<KeyCheckMarks> {
               (index) => Padding(
                 padding: const EdgeInsets.all(2),
                 child: SizedBox(
+                  key: _checkmarkKey(40 + checkmarkIndex + index),
                   width: widget.checkmarkSize,
                   height: widget.checkmarkSize,
                   child: buildCheckmark(context, 40 + checkmarkIndex + index,

--- a/chameleonultragui/test/key_check_marks_test.dart
+++ b/chameleonultragui/test/key_check_marks_test.dart
@@ -1,0 +1,65 @@
+import 'dart:typed_data';
+
+import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
+import 'package:chameleonultragui/gui/component/key_check_marks.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/recovery.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('long press and drag applies the initial key action in bulk',
+      (tester) async {
+    final checkMarks =
+        List.filled(80, ChameleonKeyCheckmark.none, growable: false);
+    final validKeys = List.generate(80, (_) => Uint8List(0), growable: false);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (context, setState) {
+              return KeyCheckMarks(
+                checkMarks: checkMarks,
+                validKeys: validKeys,
+                checkmarkCount: 3,
+                checkmarkPerRow: 3,
+                onCheckmarkChanged: (index, newValue) {
+                  setState(() => checkMarks[index] = newValue);
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    final firstKey = tester.getCenter(find.byIcon(Icons.close).at(0));
+    final secondKey = tester.getCenter(find.byIcon(Icons.close).at(1));
+    final gesture = await tester.startGesture(firstKey);
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 100));
+    await gesture.moveTo(secondKey);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    expect(checkMarks[0], ChameleonKeyCheckmark.disabled);
+    expect(checkMarks[1], ChameleonKeyCheckmark.disabled);
+    expect(checkMarks[2], ChameleonKeyCheckmark.none);
+
+    final firstDisabledKey = tester.getCenter(find.byIcon(Icons.cancel).at(0));
+    final secondDisabledKey = tester.getCenter(find.byIcon(Icons.cancel).at(1));
+    final enableGesture = await tester.startGesture(firstDisabledKey);
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 100));
+    await enableGesture.moveTo(secondDisabledKey);
+    await tester.pump();
+    await enableGesture.up();
+    await tester.pump();
+
+    expect(checkMarks[0], ChameleonKeyCheckmark.none);
+    expect(checkMarks[1], ChameleonKeyCheckmark.none);
+    expect(checkMarks[2], ChameleonKeyCheckmark.none);
+  });
+}


### PR DESCRIPTION
Implements a new feature on the saved cards page:

Press and hold a sectors checkmark / key and drag to bulk toggle

closes #788 