### PR TITLE
ci: build and publish Linux arm64 artifacts

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -118,6 +118,34 @@ jobs:
           name: linux-legacy
           path: chameleonultragui/build/linux/x64/release/bundle
 
+  build-linux-arm64:
+    needs: check
+    runs-on: ubuntu-24.04-arm
+    defaults:
+      run:
+        working-directory: ./chameleonultragui
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+      - run:
+          sudo apt-get update -y && sudo apt-get install -y ninja-build libgtk-3-dev
+          clang
+      - run: flutter config --enable-linux-desktop
+      - run: flutter build linux --build-number ${{ github.run_number }}
+      - run: flutter test
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-arm64
+          path: chameleonultragui/build/linux/arm64/release/bundle
+      - run: dart pub global activate flutter_to_debian
+      - run: flutter_to_debian
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-debian-arm64
+          path: chameleonultragui/build/linux/arm64/release/debian
+
   build-macos:
     needs: check
     runs-on: macos-latest
@@ -163,13 +191,14 @@ jobs:
       - build-windows
       - build-linux
       - build-linux-legacy
+      - build-linux-arm64
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
       - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: "{apk,windows,windows-installer,linux,linux-debian,linux-legacy}"
+          pattern: "{apk,windows,windows-installer,linux,linux-debian,linux-legacy,linux-arm64,linux-debian-arm64}"
           path: release-artifacts
       - name: Create zip files from artifacts
         run: |
@@ -207,13 +236,14 @@ jobs:
       - build-windows
       - build-linux
       - build-linux-legacy
+      - build-linux-arm64
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
       - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: "{apk,windows,windows-installer,linux,linux-debian,linux-legacy}"
+          pattern: "{apk,windows,windows-installer,linux,linux-debian,linux-legacy,linux-arm64,linux-debian-arm64}"
           path: release-artifacts
       - name: Create zip files from artifacts
         run: |


### PR DESCRIPTION
Noticed there's no arm64 Linux build — every Linux artifact is x64, so anyone on aarch64 (Asahi/Linux on Apple Silicon, SBCs, ARM workstations, Grace/DGX boxes) has nothing to grab, and the amd64 `.deb` won't install there.

This adds a `build-linux-arm64` job that mirrors the existing `build-linux` one but runs on GitHub's `ubuntu-24.04-arm` runner (free for public repos). Same steps — `flutter build linux` + `flutter_to_debian` — so it produces `linux-arm64` and `linux-debian-arm64` artifacts, wired into the dev + tagged release jobs.

Built it locally on Ubuntu 24.04 aarch64 with Flutter stable first — compiles and runs clean as a native arm64 binary, no code changes needed. Since the workflow runs on PRs, the arm64 job here should prove itself green.