### PR TITLE
Add Jablotron LF tag support (read, emulate, write to T55xx)

### DIFF
--- a/chameleonultragui/lib/bridge/chameleon.dart
+++ b/chameleonultragui/lib/bridge/chameleon.dart
@@ -591,6 +591,16 @@ class ChameleonCommunicator {
     return IoProxCard.fromBytes(resp.data);
   }
 
+  Future<JablotronCard?> readJablotron() async {
+    var resp = await sendCmd(ChameleonCommand.scanJablotronTag);
+
+    if (resp!.data.isEmpty) {
+      return null;
+    }
+
+    return JablotronCard.fromBytes(resp.data);
+  }
+
   Future<void> setEM410XEmulatorID(Uint8List uid) async {
     await sendCmd(ChameleonCommand.setEM410XemulatorID, data: uid);
   }
@@ -609,6 +619,10 @@ class ChameleonCommunicator {
 
   Future<void> setIoProxEmulatorID(Uint8List uid) async {
     await sendCmd(ChameleonCommand.setIoProxEmulatorID, data: uid);
+  }
+
+  Future<void> setJablotronEmulatorID(Uint8List uid) async {
+    await sendCmd(ChameleonCommand.setJablotronEmulatorID, data: uid);
   }
 
   Future<void> setIdteckEmulatorID(Uint8List uid) async {
@@ -660,6 +674,20 @@ class ChameleonCommunicator {
     }
 
     await sendCmd(ChameleonCommand.writeVikingToT5577,
+        data: Uint8List.fromList([...uid, ...newKey, ...keys]));
+  }
+
+  Future<void> writeJablotronToT55XX(
+      Uint8List uid, Uint8List newKey, List<Uint8List> oldKeys) async {
+    List<int> keys = [];
+
+    keys.addAll(newKey);
+
+    for (var oldKey in oldKeys) {
+      keys.addAll(oldKey);
+    }
+
+    await sendCmd(ChameleonCommand.writeJablotronToT5577,
         data: Uint8List.fromList([...uid, ...newKey, ...keys]));
   }
 
@@ -1095,6 +1123,11 @@ class ChameleonCommunicator {
   Future<IoProxCard> getIoProxEmulatorID() async {
     return IoProxCard.fromBytes(
         (await sendCmd(ChameleonCommand.getIoProxEmulatorID))!.data);
+  }
+
+  Future<JablotronCard> getJablotronEmulatorID() async {
+    return JablotronCard.fromBytes(
+        (await sendCmd(ChameleonCommand.getJablotronEmulatorID))!.data);
   }
 
   Future<IdteckCard> getIdteckEmulatorID() async {

--- a/chameleonultragui/lib/gui/menu/dialogs/slot/edit.dart
+++ b/chameleonultragui/lib/gui/menu/dialogs/slot/edit.dart
@@ -230,6 +230,9 @@ class SlotEditMenuState extends State<SlotEditMenu> {
         await appState.communicator!
             .setHIDProxEmulatorID(hexToBytes(hidCard.toString()));
       } catch (_) {}
+    } else if (selectedType! == TagType.jablotron) {
+      await appState.communicator!.setJablotronEmulatorID(
+          hexToBytes(uidController.text.replaceAll(' ', '')));
     } else if (selectedType! == TagType.pac) {
       await appState.communicator!.setPacEmulatorID(
           hexToBytes(uidController.text.replaceAll(' ', '')));

--- a/chameleonultragui/lib/gui/menu/dialogs/slot/edit.dart
+++ b/chameleonultragui/lib/gui/menu/dialogs/slot/edit.dart
@@ -105,6 +105,12 @@ class SlotEditMenuState extends State<SlotEditMenu> {
             await appState.communicator!.getVikingEmulatorID();
         uidController.text = bytesToHexSpace(vikingCard.uid);
       } catch (_) {}
+    } else if (selectedType! == TagType.jablotron) {
+      try {
+        JablotronCard jablotronCard =
+            await appState.communicator!.getJablotronEmulatorID();
+        uidController.text = bytesToHexSpace(jablotronCard.uid);
+      } catch (_) {}
     } else if (selectedType! == TagType.pac) {
       try {
         PacCard pacCard = await appState.communicator!.getPacEmulatorID();

--- a/chameleonultragui/lib/gui/menu/dialogs/slot/export.dart
+++ b/chameleonultragui/lib/gui/menu/dialogs/slot/export.dart
@@ -56,6 +56,13 @@ class SlotExportMenuState extends State<SlotExportMenu> {
           name: widget.names.lf,
           tag: widget.slotTypes.lf,
         );
+      } else if (widget.slotTypes.lf == TagType.jablotron) {
+        return CardSave(
+          uid: (await appState.communicator!.getJablotronEmulatorID())
+              .toString(),
+          name: widget.names.lf,
+          tag: widget.slotTypes.lf,
+        );
       } else if (widget.slotTypes.lf == TagType.pac) {
         return CardSave(
           uid: (await appState.communicator!.getPacEmulatorID()).toString(),

--- a/chameleonultragui/lib/gui/page/read_card.dart
+++ b/chameleonultragui/lib/gui/page/read_card.dart
@@ -129,6 +129,7 @@ class ReadCardPageState extends State<ReadCardPage> {
     card ??= await appState.communicator!.readViking();
     card ??= await appState.communicator!.readPac();
     card ??= await appState.communicator!.readIoProx();
+    card ??= await appState.communicator!.readJablotron();
 
 
     if (card != null) {

--- a/chameleonultragui/lib/gui/page/slot_manager.dart
+++ b/chameleonultragui/lib/gui/page/slot_manager.dart
@@ -202,6 +202,22 @@ class SlotManagerPageState extends State<SlotManagerPage> {
       await appState.communicator!.saveSlotData();
       appState.changesMade();
       refreshSlot();
+    } else if (card.tag == TagType.jablotron) {
+      close(context, card.name);
+      await appState.communicator!.setReaderDeviceMode(false);
+      await appState.communicator!
+          .enableSlot(gridPosition, TagFrequency.lf, true);
+      await appState.communicator!.activateSlot(gridPosition);
+      await appState.communicator!.setSlotType(gridPosition, card.tag);
+      await appState.communicator!.setDefaultDataToSlot(gridPosition, card.tag);
+      await appState.communicator!.setJablotronEmulatorID(hexToBytes(card.uid));
+      await appState.communicator!.setSlotTagName(
+          gridPosition,
+          (card.name.isEmpty) ? localizations.no_name : card.name,
+          TagFrequency.lf);
+      await appState.communicator!.saveSlotData();
+      appState.changesMade();
+      refreshSlot();
     } else if (card.tag == TagType.pac) {
       close(context, card.name);
       await appState.communicator!.setReaderDeviceMode(false);

--- a/chameleonultragui/lib/helpers/definitions.dart
+++ b/chameleonultragui/lib/helpers/definitions.dart
@@ -91,6 +91,8 @@ enum ChameleonCommand {
   scanPacTag(3014),
   writePacToT5577(3015),
   writeIdteckToT5577(3018),
+  scanJablotronTag(3019),
+  writeJablotronToT5577(3020),
   lfSniff(3031),
 
   mf1LoadBlockData(4000),
@@ -155,6 +157,9 @@ enum ChameleonCommand {
   setIoProxEmulatorID(5008),
   getIoProxEmulatorID(5009),
 
+  setJablotronEmulatorID(5010),
+  getJablotronEmulatorID(5011),
+
   setIdteckEmulatorID(5012),
   getIdteckEmulatorID(5013);
 
@@ -171,6 +176,7 @@ enum TagType {
   em410XElectra(104),
   pac(150),
   viking(170),
+  jablotron(180),
   hidProx(200),
   ioProx(201),
   idteck(310),
@@ -607,6 +613,26 @@ class VikingCard extends LFCard {
 
   VikingCard({
     super.type = TagType.viking,
+    required super.uid,
+  });
+}
+
+class JablotronCard extends LFCard {
+  factory JablotronCard.fromBytes(Uint8List bytes) {
+    return JablotronCard(uid: bytes);
+  }
+
+  factory JablotronCard.fromUID(String uid) {
+    return JablotronCard.fromBytes(hexToBytes(uid));
+  }
+
+  @override
+  String toViewableString() {
+    return '${jablotronCardId(uid)} (${bytesToHexSpace(uid)})';
+  }
+
+  JablotronCard({
+    super.type = TagType.jablotron,
     required super.uid,
   });
 }

--- a/chameleonultragui/lib/helpers/general.dart
+++ b/chameleonultragui/lib/helpers/general.dart
@@ -164,6 +164,8 @@ String chameleonTagToString(TagType tag, AppLocalizations localizations) {
     return "HID Prox";
   } else if (tag == TagType.viking) {
     return "Viking";
+  } else if (tag == TagType.jablotron) {
+    return "Jablotron";
   } else if (tag == TagType.pac) {
     return "PAC/Stanley";
   } else if (tag == TagType.ioProx) {
@@ -455,6 +457,7 @@ List<TagType> getTagTypesByFrequency(TagFrequency frequency) {
       TagType.em410XElectra,
       TagType.hidProx,
       TagType.viking,
+      TagType.jablotron,
       TagType.pac,
       TagType.ioProx,
       TagType.idteck
@@ -553,6 +556,10 @@ LFCard getLFCardFromUID(TagType type, String uid) {
     return VikingCard.fromUID(uid);
   }
 
+  if (type == TagType.jablotron) {
+    return JablotronCard.fromUID(uid);
+  }
+
   if (type == TagType.pac) {
     return PacCard.fromUID(uid);
   }
@@ -577,6 +584,8 @@ int uidSizeForLfTag(TagType type) {
     return 5;
   } else if (type == TagType.viking) {
     return 4;
+  } else if (type == TagType.jablotron) {
+    return 5;
   } else if (type == TagType.pac) {
     return 8;
   } else if (type == TagType.ioProx) {
@@ -596,6 +605,15 @@ bool isEM410X(TagType type) {
     TagType.em410X64,
     TagType.em410XElectra
   ].contains(type);
+}
+
+// Converts the 5 raw Jablotron bytes to the decimal card number via BCD.
+int jablotronCardId(Uint8List bytes) {
+  int cardId = 0;
+  for (var b in bytes) {
+    cardId = cardId * 100 + ((b >> 4) * 10) + (b & 0x0F);
+  }
+  return cardId;
 }
 
 Future<(HFCardInfo, MifareClassicInfo, MifareUltralightInfo)> readHFInfo(

--- a/chameleonultragui/lib/helpers/t55xx/write/base.dart
+++ b/chameleonultragui/lib/helpers/t55xx/write/base.dart
@@ -164,6 +164,12 @@ class BaseT55XXCardHelper extends AbstractWriteHelper {
       await Future.delayed(const Duration(milliseconds: 500));
       var newCard = await communicator.readViking();
       return newCard.toString() == card.uid;
+    } else if (card.tag == TagType.jablotron) {
+      await communicator.writeJablotronToT55XX(hexToBytes(card.uid),
+          hexToBytes(newKey), [hexToBytes(currentKey), Uint8List(4)]);
+      await Future.delayed(const Duration(milliseconds: 500));
+      var newCard = await communicator.readJablotron();
+      return newCard.toString() == card.uid;
     } else if (card.tag == TagType.pac) {
       await communicator.writePacToT55XX(hexToBytes(card.uid),
           hexToBytes(newKey), [hexToBytes(currentKey), Uint8List(4)]);

--- a/chameleonultragui/lib/helpers/write.dart
+++ b/chameleonultragui/lib/helpers/write.dart
@@ -64,6 +64,7 @@ abstract class AbstractWriteHelper {
     if (isEM410X(type) ||
         type == TagType.hidProx ||
         type == TagType.viking ||
+        type == TagType.jablotron ||
         type == TagType.pac ||
         type == TagType.ioProx ||
         type == TagType.idteck) {

--- a/chameleonultragui/test/jablotron_test.dart
+++ b/chameleonultragui/test/jablotron_test.dart
@@ -1,0 +1,39 @@
+import 'dart:typed_data';
+
+import 'package:chameleonultragui/helpers/definitions.dart';
+import 'package:chameleonultragui/helpers/general.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('jablotronCardId converts raw bytes to decimal via BCD', () {
+    // Each byte is read as two BCD digits, concatenated across the 5 bytes.
+    expect(
+      jablotronCardId(Uint8List.fromList([0x00, 0x12, 0x34, 0x56, 0x78])),
+      12345678,
+    );
+    expect(
+      jablotronCardId(Uint8List.fromList([0x00, 0x00, 0x00, 0x00, 0x00])),
+      0,
+    );
+    expect(
+      jablotronCardId(Uint8List.fromList([0x00, 0x00, 0x00, 0x00, 0x01])),
+      1,
+    );
+  });
+
+  test('JablotronCard exposes type, hex string and decimal card number', () {
+    final card = JablotronCard.fromUID('0012345678');
+
+    expect(card.type, TagType.jablotron);
+    expect(card.toString(), '00 12 34 56 78');
+    expect(card.toViewableString(), '12345678 (00 12 34 56 78)');
+  });
+
+  test('JablotronCard round-trips through bytes', () {
+    final bytes = Uint8List.fromList([0x00, 0x12, 0x34, 0x56, 0x78]);
+    final card = JablotronCard.fromBytes(bytes);
+
+    expect(card.uid, bytes);
+    expect(card.type, TagType.jablotron);
+  });
+}


### PR DESCRIPTION
## Summary

Adds support for the Jablotron LF tag, threaded through the GUI the same way the
other LF tags (EM410X, Viking, PAC, HID Prox, ioProx, IDTECK) are. Jablotron is a
5-byte (40-bit) tag; its ID is shown both as hex and as the decimal card number
(BCD-derived), matching the Python CLI output.

## What's included

- `TagType.jablotron` (180) and commands `JABLOTRON_SCAN` (3019),
  `JABLOTRON_WRITE_TO_T55XX` (3020), `JABLOTRON_SET_EMU_ID` (5010),
  `JABLOTRON_GET_EMU_ID` (5011).
- `JablotronCard` whose viewable string shows the decimal card number alongside the
  hex ID.
- Read a Jablotron tag (added to the LF scan chain on the Read Card page).
- Emulate: set/get the Jablotron emulator ID on a slot (slot grid write, slot Edit
  dialog, and export).
- Write a Jablotron ID to a T55xx tag, with read-back verification.
- Unit test covering the BCD card-number conversion, the viewable string, and a byte
  round-trip.

## Firmware dependency

Requires ChameleonUltra firmware with Jablotron support (the device-side commands).
That support is currently in the firmware's `main` branch (reachable via the app's
bleeding-edge firmware update) but is not yet in a tagged firmware release. On
firmware without Jablotron support the actions degrade gracefully — a scan returns
empty and the LF read chain moves on.

## Capability gate — intentionally left unchanged

`home.dart`'s `areCapabilitiesSupported()` uses `setIdteckEmulatorID` as a single
"is the firmware recent enough" sentinel. It does not specifically probe for
Jablotron, so a firmware that has IDTECK but predates Jablotron would pass the check
yet still not support Jablotron. This is left as-is on purpose: the check only drives
a global, non-blocking "please update firmware" banner, and bumping the sentinel to a
Jablotron command would show that banner to everyone still on a pre-Jablotron
firmware. That's better sequenced alongside a tagged firmware release that includes
Jablotron. Happy to add the sentinel bump if a maintainer prefers.

## Testing

Verified on Android (`1.3.0 (Build 4)`):

- [x] Set the Jablotron emulator ID on a slot and read it back via the slot Edit
  dialog — round-trips correctly (hex + decimal card number).

Still to test:

- [ ] Read/scan a real Jablotron tag on the Read Card page
- [ ] Save a scanned Jablotron tag into the cards list; reopen and verify hex ID +
  decimal card number
- [x] Emulate a GUI-configured Jablotron slot against a real reader
- [ ] Write a Jablotron ID to a T55xx tag from the GUI and read it back
- [ ] Export a Jablotron slot to a saved card
- [ ] Confirm the decimal card number matches a known physical tag
- [ ] Desktop build sanity check (Linux / Windows / macOS)
