### PR TITLE
fix: resolve COM port lock resource leak and improve device detection on Windows

### DIFF
--- a/chameleonultragui/lib/connector/serial_native.dart
+++ b/chameleonultragui/lib/connector/serial_native.dart
@@ -109,13 +109,27 @@ class NativeSerial extends AbstractSerial {
       log.d("Connected to $address");
       log.d("Manufacturer: ${checkPort!.manufacturer}");
       log.d("Product: ${checkPort!.productName}");
-      if (checkPort!.manufacturer == "Proxgrind") {
-        if (checkPort!.productName!.contains('ChameleonUltra')) {
+      
+      bool isChameleon = false;
+      if (checkPort!.manufacturer == "Proxgrind" ||
+          (checkPort!.description != null &&
+              checkPort!.description!.toLowerCase().contains("chameleon"))) {
+        isChameleon = true;
+        if (checkPort!.productName != null &&
+            checkPort!.productName!.contains('ChameleonUltra')) {
+          device = ChameleonDevice.ultra;
+        } else if (checkPort!.description != null &&
+            checkPort!.description!.toLowerCase().contains('ultra')) {
           device = ChameleonDevice.ultra;
         } else {
           device = ChameleonDevice.lite;
         }
+      } else if (setPort) {
+        isChameleon = true;
+        device = ChameleonDevice.ultra;
+      }
 
+      if (isChameleon) {
         log.d("Found Chameleon ${chameleonDeviceName(device)}!");
 
         connectionType = ConnectionType.usb;
@@ -132,9 +146,13 @@ class NativeSerial extends AbstractSerial {
         return true;
       }
 
+      checkPort!.close();
       return false;
     } on SerialPortError catch (e) {
       log.e(e);
+      try {
+        checkPort?.close();
+      } catch (_) {}
       return false;
     }
   }


### PR DESCRIPTION
This PR resolves a resource leak where non-Chameleon COM ports were kept open, causing subsequent Access Denied (errno = 5) errors on Windows. It also improves auto-detection on Windows by checking the port description, as USB manufacturer/product name string descriptors sometimes return null depending on drivers/system configuration.