### PR TITLE
feat: T55xx reset tool to open config and clear password

### DIFF
--- a/chameleonultragui/lib/bridge/chameleon.dart
+++ b/chameleonultragui/lib/bridge/chameleon.dart
@@ -635,6 +635,108 @@ class ChameleonCommunicator {
     throw ("Invalid EM410X UID length");
   }
 
+  /// Low-level T55xx block write (firmware cmd 3016).
+  /// [word] is a 32-bit page-0/1 data word; [password] is used when [usePassword] is true.
+  Future<void> writeT55xxBlock(
+    int block,
+    int word, {
+    Uint8List? password,
+    bool usePassword = false,
+    bool page1 = false,
+  }) async {
+    if (block < 0 || block > 7) {
+      throw ArgumentError('T55xx block must be 0-7');
+    }
+    final pwd = password ?? Uint8List(4);
+    if (pwd.length != 4) {
+      throw ArgumentError('T55xx password must be 4 bytes');
+    }
+
+    final payload = Uint8List(11);
+    payload[0] = block & 0xFF;
+    payload[1] = (word >> 24) & 0xFF;
+    payload[2] = (word >> 16) & 0xFF;
+    payload[3] = (word >> 8) & 0xFF;
+    payload[4] = word & 0xFF;
+    payload[5] = usePassword ? 1 : 0;
+    payload.setRange(6, 10, pwd);
+    payload[10] = page1 ? 1 : 0;
+
+    final resp = await sendCmd(ChameleonCommand.lfT55xxWrite, data: payload);
+    // 0x40 = LF_TAG_OK
+    if (resp != null && resp.status != 0x40 && resp.status != 0x68) {
+      throw Exception(
+          'T55xx write block $block failed (status=0x${resp.status.toRadixString(16)})');
+    }
+  }
+
+  /// Reset a T55xx to open (no-password) state and wipe data blocks.
+  ///
+  /// Chameleon EM410x clones always set the PWD bit with default key
+  /// 0x20206666, which blocks cheap cloners that only do open writes.
+  /// Firmware does not verify T55xx writes over the air, so we blast the
+  /// open-config + wipe sequence using each candidate password (and open).
+  ///
+  /// Returns the primary password tried first (user/default), for UI status.
+  Future<String?> resetT55xxToOpen({
+    List<Uint8List>? passwords,
+    bool wipeDataBlocks = true,
+  }) async {
+    // Proxmark-compatible open wipe config: no PWD bit.
+    // Other tools recognize this as a blank/open T5557.
+    const int openConfig = 0x000880E0;
+
+    final candidates = <Uint8List>[
+      ...?passwords,
+      Uint8List.fromList([0x20, 0x20, 0x66, 0x66]), // Chameleon default
+      Uint8List.fromList([0x00, 0x00, 0x00, 0x00]),
+      Uint8List.fromList([0x51, 0x24, 0x36, 0x48]),
+      Uint8List.fromList([0x19, 0x92, 0x04, 0x27]),
+      Uint8List.fromList([0xFF, 0xFF, 0xFF, 0xFF]),
+    ];
+
+    // De-dupe by hex
+    final seen = <String>{};
+    final unique = <Uint8List>[];
+    for (final p in candidates) {
+      if (p.length != 4) continue;
+      final key = bytesToHex(p);
+      if (seen.add(key)) unique.add(p);
+    }
+
+    final primary =
+        unique.isNotEmpty ? bytesToHex(unique.first).toUpperCase() : null;
+
+    // 1) Open write of config (works if PWD already off).
+    await writeT55xxBlock(0, openConfig, usePassword: false);
+
+    // 2) Password-authenticated open config + clear block 7 for every candidate.
+    //    Only the correct password will stick; wrong ones are ignored by the chip.
+    for (final pwd in unique) {
+      await writeT55xxBlock(0, openConfig, password: pwd, usePassword: true);
+      await writeT55xxBlock(7, 0x00000000, password: pwd, usePassword: true);
+    }
+
+    if (wipeDataBlocks) {
+      // 3) Zero data blocks open + with each password.
+      for (int block = 1; block <= 7; block++) {
+        await writeT55xxBlock(block, 0x00000000, usePassword: false);
+        for (final pwd in unique) {
+          await writeT55xxBlock(block, 0x00000000,
+              password: pwd, usePassword: true);
+        }
+      }
+      // 4) Final open config again (open + each password).
+      await writeT55xxBlock(0, openConfig, usePassword: false);
+      for (final pwd in unique) {
+        await writeT55xxBlock(0, openConfig, password: pwd, usePassword: true);
+      }
+      await writeT55xxBlock(0, openConfig, usePassword: false);
+    }
+
+    return primary;
+  }
+
   Future<void> writeHIDProxToT55XX(
       Uint8List uid, Uint8List newKey, List<Uint8List> oldKeys) async {
     List<int> keys = [];

--- a/chameleonultragui/lib/gui/menu/tools/t55xx_reset.dart
+++ b/chameleonultragui/lib/gui/menu/tools/t55xx_reset.dart
@@ -1,0 +1,201 @@
+import 'dart:typed_data';
+
+import 'package:chameleonultragui/helpers/general.dart';
+import 'package:chameleonultragui/helpers/validators.dart';
+import 'package:chameleonultragui/main.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
+
+/// Reset T55xx to open (no-password) blank-ish state so other tools can rewrite it.
+///
+/// After Chameleon EM410x clone writes, the tag has PWD enabled (default
+/// 20206666). Cheap cloners only do open writes and then fail. This tool
+/// disables the password bit and wipes data blocks.
+class T55XXResetMenu extends StatefulWidget {
+  const T55XXResetMenu({super.key});
+
+  @override
+  T55XXResetMenuState createState() => T55XXResetMenuState();
+}
+
+class T55XXResetMenuState extends State<T55XXResetMenu> {
+  final TextEditingController passwordController =
+      TextEditingController(text: '20206666');
+  bool isProcessing = false;
+  bool wipeData = true;
+  bool tryCommonPasswords = true;
+  String? statusMessage;
+  bool? success;
+
+  @override
+  void dispose() {
+    passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _runReset() async {
+    var appState = context.read<ChameleonGUIState>();
+    var localizations = AppLocalizations.of(context)!;
+
+    final pwdText = passwordController.text.replaceAll(RegExp(r'[^0-9A-Fa-f]'), '');
+    if (pwdText.length != 8) {
+      setState(() {
+        success = false;
+        statusMessage = localizations.t55xx_reset_invalid_password;
+      });
+      return;
+    }
+
+    setState(() {
+      isProcessing = true;
+      success = null;
+      statusMessage = localizations.t55xx_reset_in_progress;
+    });
+
+    try {
+      if (!await appState.communicator!.isReaderDeviceMode()) {
+        await appState.communicator!.setReaderDeviceMode(true);
+      }
+
+      final passwords = <Uint8List>[hexToBytes(pwdText)];
+      if (tryCommonPasswords) {
+        // Built-in common cloner / CU passwords (in addition to user field).
+        passwords.addAll([
+          Uint8List.fromList([0x20, 0x20, 0x66, 0x66]),
+          Uint8List.fromList([0x00, 0x00, 0x00, 0x00]),
+          Uint8List.fromList([0x51, 0x24, 0x36, 0x48]),
+          Uint8List.fromList([0x19, 0x92, 0x04, 0x27]),
+          Uint8List.fromList([0xFF, 0xFF, 0xFF, 0xFF]),
+        ]);
+      }
+
+      final used = await appState.communicator!.resetT55xxToOpen(
+        passwords: passwords,
+        wipeDataBlocks: wipeData,
+      );
+
+      if (!mounted) return;
+      setState(() {
+        isProcessing = false;
+        success = true;
+        // Firmware cannot confirm which password stuck; show primary tried.
+        statusMessage = used != null
+            ? localizations.t55xx_reset_success_with_password(used)
+            : localizations.t55xx_reset_success_open;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        isProcessing = false;
+        success = false;
+        statusMessage = '${localizations.t55xx_reset_failed}: $e';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var localizations = AppLocalizations.of(context)!;
+
+    return AlertDialog(
+      title: Text(localizations.t55xx_reset_title),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Card(
+              color: Colors.orange.withValues(alpha: 0.1),
+              child: Padding(
+                padding: const EdgeInsets.all(12.0),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Icon(Icons.info_outline, color: Colors.orange),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        localizations.t55xx_reset_description,
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              localizations.t55xx_reset_password_label,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            TextFormField(
+              controller: passwordController,
+              enabled: !isProcessing,
+              decoration: InputDecoration(
+                border: const OutlineInputBorder(),
+                hintText: '20206666',
+                helperText: localizations.t55xx_reset_password_hint,
+              ),
+              inputFormatters: hexFormatter,
+              onChanged: (_) => setState(() {}),
+            ),
+            const SizedBox(height: 8),
+            CheckboxListTile(
+              contentPadding: EdgeInsets.zero,
+              value: tryCommonPasswords,
+              onChanged: isProcessing
+                  ? null
+                  : (v) => setState(() => tryCommonPasswords = v ?? true),
+              title: Text(localizations.t55xx_reset_try_common),
+              controlAffinity: ListTileControlAffinity.leading,
+            ),
+            CheckboxListTile(
+              contentPadding: EdgeInsets.zero,
+              value: wipeData,
+              onChanged: isProcessing
+                  ? null
+                  : (v) => setState(() => wipeData = v ?? true),
+              title: Text(localizations.t55xx_reset_wipe_data),
+              controlAffinity: ListTileControlAffinity.leading,
+            ),
+            if (isProcessing) ...[
+              const SizedBox(height: 16),
+              const LinearProgressIndicator(),
+              const SizedBox(height: 8),
+              Text(localizations.t55xx_reset_in_progress),
+            ],
+            if (statusMessage != null && !isProcessing) ...[
+              const SizedBox(height: 16),
+              Card(
+                color: (success == true
+                        ? Colors.green
+                        : success == false
+                            ? Colors.red
+                            : Colors.grey)
+                    .withValues(alpha: 0.12),
+                child: Padding(
+                  padding: const EdgeInsets.all(12.0),
+                  child: Text(statusMessage!),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: isProcessing ? null : () => Navigator.of(context).pop(),
+          child: Text(localizations.close),
+        ),
+        ElevatedButton.icon(
+          onPressed: isProcessing ? null : _runReset,
+          icon: const Icon(Icons.restart_alt),
+          label: Text(localizations.t55xx_reset_start),
+        ),
+      ],
+    );
+  }
+}

--- a/chameleonultragui/lib/gui/page/tools.dart
+++ b/chameleonultragui/lib/gui/page/tools.dart
@@ -3,6 +3,7 @@ import 'package:chameleonultragui/gui/menu/tools/dictionary_download.dart';
 import 'package:chameleonultragui/gui/menu/tools/hf_sniffing.dart';
 import 'package:chameleonultragui/gui/menu/tools/lf_sniffing.dart';
 import 'package:chameleonultragui/gui/menu/tools/t55xx_password_cleaner.dart';
+import 'package:chameleonultragui/gui/menu/tools/t55xx_reset.dart';
 import 'package:chameleonultragui/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
@@ -46,6 +47,12 @@ class ToolsPageState extends State<ToolsPage> {
           description: localizations.dictionary_download_description,
           icon: Icons.key,
           onPressed: const DictionaryDownloadMenu()),
+      ToolItem(
+          name: localizations.t55xx_reset_title,
+          description: localizations.t55xx_reset_description,
+          icon: Icons.lock_open,
+          onPressed: const T55XXResetMenu(),
+          isDeviceRequired: true),
       ToolItem(
           name: localizations.t55xx_password_cleaner,
           description: localizations.t55xx_password_cleaner_description,

--- a/chameleonultragui/lib/helpers/definitions.dart
+++ b/chameleonultragui/lib/helpers/definitions.dart
@@ -90,6 +90,7 @@ enum ChameleonCommand {
   writeIoProxToT5577(3011),
   scanPacTag(3014),
   writePacToT5577(3015),
+  lfT55xxWrite(3016),
   writeIdteckToT5577(3018),
   lfSniff(3031),
 

--- a/chameleonultragui/lib/l10n/app_en.arb
+++ b/chameleonultragui/lib/l10n/app_en.arb
@@ -404,6 +404,25 @@
   "password_reset_success": "Previous password was: {password}",
   "password_reset_no_match": "Unable to reset password. None of the password in the dictionary worked.",
   "trying_password": "Trying password",
+  "t55xx_reset_title": "T55XX reset (open / no password)",
+  "t55xx_reset_description": "Resets a T55xx (T5557) so other tools can rewrite it. Chameleon EM410x clones enable the password bit (default 20206666); this clears password protection, writes an open config, and optionally wipes data blocks. Hold the tag on the Ultra LF antenna. Risk of bricking if wrong password / wrong chip.",
+  "t55xx_reset_password_label": "Known password",
+  "t55xx_reset_password_hint": "Default after Chameleon clone: 20206666",
+  "t55xx_reset_try_common": "Also try common passwords (00000000, 51243648, ...)",
+  "t55xx_reset_wipe_data": "Wipe data blocks 1–7 (blank tag)",
+  "t55xx_reset_start": "Reset to open T5557",
+  "t55xx_reset_in_progress": "Resetting tag… keep it still on the antenna",
+  "t55xx_reset_invalid_password": "Password must be 4 hex bytes (8 characters), e.g. 20206666",
+  "t55xx_reset_success_with_password": "Commands sent (tried password {password} and common keys). Tag should be open T5557 with password disabled. Verify with your other tool; if it still fails, try again with the correct password.",
+  "@t55xx_reset_success_with_password": {
+    "placeholders": {
+      "password": {
+        "type": "String"
+      }
+    }
+  },
+  "t55xx_reset_success_open": "Commands sent. Tag should be open T5557 with password disabled. Verify with your other tool.",
+  "t55xx_reset_failed": "Reset failed",
   "failed_to_read_block": "Failed to read any blocks. This is password protected card or not Mifare Ultralight card",
   "android_ble_permissions_missing": "Missing BLE or location permission. To connect via BLE, grant permissions in your device Settings app",
   "skip_recovery": "Skip recovery",


### PR DESCRIPTION
## Summary
Chameleon EM410x to T55xx clone always sets the PWD bit (default password `0x20206666`). Cheap cloners and some PC tools only do open writes and can no longer set up T5557 or disable password after a Chameleon write.

Adds **Tools → T55XX reset (open / no password)**:
- Expose firmware LF T55xx block write (cmd 3016)
- Rewrite open config (`0x000880E0`, no PWD bit), clear block 7, optional wipe of data blocks
- Try user password (default `20206666`) plus common cloner keys

Does **not** change default clone/write behavior (still password-protected). Existing T55XX password cleaner remains (dictionary attack sets a new password; still PWD mode).

## Test plan
- [ ] Ultra only: write EM410x to T55xx with default keys; other open-write tool fails
- [ ] Run T55XX reset with `20206666`; other tool can set up T5557 / rewrite again
- [ ] Lite / old firmware without cmd 3016 fails cleanly without breaking other tools
- [ ] Password cleaner tool still works as before
