### PR TITLE
Add RF session ownership and destructive-write safety

### DIFF
--- a/chameleonultragui/lib/gui/component/slot_changer.dart
+++ b/chameleonultragui/lib/gui/component/slot_changer.dart
@@ -1,4 +1,5 @@
 import 'package:chameleonultragui/gui/component/error_page.dart';
+import 'package:chameleonultragui/helpers/connected_device_session.dart';
 import 'package:chameleonultragui/helpers/definitions.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -21,26 +22,39 @@ class SlotChangerState extends State<SlotChanger> {
 
   Future<List<Icon>> getFutureData() async {
     var appState = context.read<ChameleonGUIState>();
-    List<SlotTypes> usedSlots;
+    final result = await appState.runSessionBoundForeground((session) async {
+      List<SlotTypes> usedSlots;
+      try {
+        usedSlots = await session.communicator.getSlotTagTypes();
+      } catch (_) {
+        usedSlots = [];
+      }
+      if (!mounted || !session.isCurrent) return null;
 
-    try {
-      usedSlots = await appState.communicator!.getSlotTagTypes();
-    } catch (_) {
-      usedSlots = [];
+      var activeSlot = 1;
+      try {
+        activeSlot = await session.communicator.getActiveSlot() + 1;
+      } catch (_) {}
+      if (!mounted || !session.isCurrent) return null;
+
+      return (usedSlots: usedSlots, activeSlot: activeSlot);
+    });
+    final session = result.session;
+    final data = result.value;
+    if (!result.executed ||
+        session == null ||
+        data == null ||
+        !mounted ||
+        !session.isCurrent) {
+      return [const Icon(Icons.warning)];
     }
 
-    return await getSlotIcons(usedSlots);
+    selectedSlot = data.activeSlot;
+    return getSlotIcons(data.usedSlots);
   }
 
-  Future<List<Icon>> getSlotIcons(List<SlotTypes> usedSlots) async {
-    var appState = context.read<ChameleonGUIState>();
+  List<Icon> getSlotIcons(List<SlotTypes> usedSlots) {
     List<Icon> icons = [];
-
-    try {
-      selectedSlot = await appState.communicator!.getActiveSlot() + 1;
-    } catch (_) {
-      selectedSlot = 1;
-    }
 
     if (usedSlots.isEmpty) {
       return [const Icon(Icons.warning)];
@@ -59,6 +73,21 @@ class SlotChangerState extends State<SlotChanger> {
       }
     }
     return icons;
+  }
+
+  Future<void> _activateSlot(int slot) async {
+    final appState = context.read<ChameleonGUIState>();
+    await appState.runSessionBoundForeground((session) async {
+      if (!mounted || !session.isCurrent) {
+        return;
+      }
+      await session.communicator.activateSlot(slot);
+      if (!mounted || !session.isCurrent) {
+        return;
+      }
+      setState(() {});
+      appState.changesMade();
+    });
   }
 
   List<Icon> presold = [
@@ -107,10 +136,7 @@ class SlotChangerState extends State<SlotChanger> {
                 IconButton(
                   onPressed: () async {
                     if (selectedSlot > 1) {
-                      await appState.communicator!
-                          .activateSlot(selectedSlot - 2);
-                      setState(() {});
-                      appState.changesMade();
+                      await _activateSlot(selectedSlot - 2);
                     }
                   },
                   icon: const Icon(Icons.arrow_back),
@@ -119,9 +145,7 @@ class SlotChangerState extends State<SlotChanger> {
                 IconButton(
                   onPressed: () async {
                     if (selectedSlot < 8) {
-                      await appState.communicator!.activateSlot(selectedSlot);
-                      setState(() {});
-                      appState.changesMade();
+                      await _activateSlot(selectedSlot);
                     }
                   },
                   icon: const Icon(Icons.arrow_forward),

--- a/chameleonultragui/lib/gui/menu/dialogs/slot/edit.dart
+++ b/chameleonultragui/lib/gui/menu/dialogs/slot/edit.dart
@@ -1,6 +1,8 @@
+import 'package:chameleonultragui/bridge/chameleon.dart';
 import 'package:chameleonultragui/gui/component/error_page.dart';
 import 'package:chameleonultragui/gui/component/toggle_buttons.dart';
 import 'package:chameleonultragui/gui/menu/pages/mfkey32.dart';
+import 'package:chameleonultragui/helpers/connected_device_session.dart';
 import 'package:chameleonultragui/helpers/definitions.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/general.dart';
 import 'package:chameleonultragui/helpers/mifare_ultralight/general.dart';
@@ -13,6 +15,10 @@ import 'package:chameleonultragui/main.dart';
 
 // Localizations
 import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
+
+class _SlotOperationCanceled implements Exception {
+  const _SlotOperationCanceled();
+}
 
 class SlotEditMenu extends StatefulWidget {
   final String name;
@@ -76,23 +82,80 @@ class SlotEditMenuState extends State<SlotEditMenu> {
     }
   }
 
+  bool _canContinue(ConnectedDeviceSession session) =>
+      mounted && session.isCurrent;
+
+  Future<T> _awaitTransport<T>(
+    ConnectedDeviceSession session,
+    Future<T> Function() operation,
+  ) async {
+    if (!_canContinue(session)) throw const _SlotOperationCanceled();
+    final result = await operation();
+    if (!_canContinue(session)) throw const _SlotOperationCanceled();
+    return result;
+  }
+
+  Future<bool> _runSlotOperation(
+    Future<void> Function(ConnectedDeviceSession session) operation,
+  ) async {
+    final appState = context.read<ChameleonGUIState>();
+    final result = await appState.runSessionBoundForeground((session) async {
+      try {
+        if (!_canContinue(session)) return false;
+        await operation(session);
+        return _canContinue(session);
+      } on _SlotOperationCanceled {
+        return false;
+      }
+    });
+    return result.executed && result.value == true;
+  }
+
+  Future<bool> _runCommand(
+    Future<void> Function(ChameleonCommunicator communicator) command,
+  ) {
+    return _runSlotOperation((session) async {
+      await _awaitTransport(
+        session,
+        () => command(session.communicator),
+      );
+    });
+  }
+
+  Future<T?> _runReadCommand<T>(
+    Future<T> Function(ChameleonCommunicator communicator) command,
+  ) async {
+    T? value;
+    final completed = await _runSlotOperation((session) async {
+      value = await _awaitTransport(
+        session,
+        () => command(session.communicator),
+      );
+    });
+    return completed ? value : null;
+  }
+
   Future<void> updateInfo() async {
-    var appState = context.watch<ChameleonGUIState>();
     if (previousTagType == selectedType ||
         isMifareClassic(previousTagType) && isMifareClassic(selectedType!)) {
       return;
     }
+    await _runSlotOperation(_updateInfo);
+  }
 
-    await appState.communicator!.activateSlot(widget.slot);
+  Future<void> _updateInfo(ConnectedDeviceSession session) async {
+    await _awaitTransport(
+        session, () => session.communicator.activateSlot(widget.slot));
 
     if (isEM410X(selectedType!)) {
       try {
-        uidController.text =
-            bytesToHexSpace(await appState.communicator!.getEM410XEmulatorID());
+        uidController.text = bytesToHexSpace(await _awaitTransport(
+            session, session.communicator.getEM410XEmulatorID));
       } catch (_) {}
     } else if (selectedType! == TagType.hidProx) {
       try {
-        HIDCard hidCard = await appState.communicator!.getHIDProxEmulatorID();
+        HIDCard hidCard = await _awaitTransport(
+            session, session.communicator.getHIDProxEmulatorID);
         uidController.text = bytesToHexSpace(hidCard.uid);
         hidTypeController.text = hidCard.hidType.toString();
         facilityCodeController.text = hidCard.facilityCode.toString();
@@ -101,57 +164,60 @@ class SlotEditMenuState extends State<SlotEditMenu> {
       } catch (_) {}
     } else if (selectedType! == TagType.viking) {
       try {
-        VikingCard vikingCard =
-            await appState.communicator!.getVikingEmulatorID();
+        VikingCard vikingCard = await _awaitTransport(
+            session, session.communicator.getVikingEmulatorID);
         uidController.text = bytesToHexSpace(vikingCard.uid);
       } catch (_) {}
     } else if (selectedType! == TagType.pac) {
       try {
-        PacCard pacCard = await appState.communicator!.getPacEmulatorID();
+        PacCard pacCard = await _awaitTransport(
+            session, session.communicator.getPacEmulatorID);
         uidController.text = bytesToHexSpace(pacCard.uid);
       } catch (_) {}
     } else if (selectedType! == TagType.ioProx) {
       try {
-        IoProxCard ioProxCard =
-            await appState.communicator!.getIoProxEmulatorID();
+        IoProxCard ioProxCard = await _awaitTransport(
+            session, session.communicator.getIoProxEmulatorID);
         uidController.text = bytesToHexSpace(ioProxCard.uid);
       } catch (_) {}
     } else if (selectedType! == TagType.idteck) {
       try {
-        IdteckCard idteckCard =
-            await appState.communicator!.getIdteckEmulatorID();
+        IdteckCard idteckCard = await _awaitTransport(
+            session, session.communicator.getIdteckEmulatorID);
         uidController.text = bytesToHexSpace(idteckCard.uid);
       } catch (_) {}
     } else if (isMifareClassic(selectedType!) ||
         isMifareUltralight(selectedType!)) {
       try {
-        CardData data = await appState.communicator!.mf1GetAntiCollData();
+        CardData data = await _awaitTransport(
+            session, session.communicator.mf1GetAntiCollData);
         uidController.text = bytesToHexSpace(data.uid);
         sakController.text = bytesToHex(u8ToBytes(data.sak));
         atqaController.text = bytesToHexSpace(data.atqa);
         atsController.text = bytesToHexSpace(data.ats);
 
         if (isMifareClassic(selectedType!)) {
-          emulatorSettings =
-              await appState.communicator!.getMf1EmulatorSettings();
+          emulatorSettings = await _awaitTransport(
+              session, session.communicator.getMf1EmulatorSettings);
 
           if (emulatorSettings!.isDetectionEnabled) {
-            detectionCount =
-                await appState.communicator!.getMf1DetectionCount();
+            detectionCount = await _awaitTransport(
+                session, session.communicator.getMf1DetectionCount);
           }
 
           try {
-            mf1PrngType = await appState.communicator!.getMf1PrngType();
+            mf1PrngType = await _awaitTransport(
+                session, session.communicator.getMf1PrngType);
           } catch (_) {
             mf1PrngType = null;
           }
         } else if (isMifareUltralight(selectedType!)) {
-          Uint8List version =
-              await appState.communicator!.mf0EmulatorGetVersionData();
+          Uint8List version = await _awaitTransport(
+              session, session.communicator.mf0EmulatorGetVersionData);
           ultralightVersionController.text = bytesToHexSpace(version);
 
-          Uint8List signature =
-              await appState.communicator!.mf0EmulatorGetSignatureData();
+          Uint8List signature = await _awaitTransport(
+              session, session.communicator.mf0EmulatorGetSignatureData);
           ultralightSignatureController.text = bytesToHexSpace(signature);
 
           if (mfUltralightHasCounters(selectedType!)) {
@@ -160,35 +226,40 @@ class SlotEditMenuState extends State<SlotEditMenu> {
 
             for (int i = 0; i < counterCount; i++) {
               TextEditingController controller = TextEditingController();
-              var counterData =
-                  await appState.communicator!.mf0EmulatorGetCounterData(i);
+              var counterData = await _awaitTransport(session,
+                  () => session.communicator.mf0EmulatorGetCounterData(i));
               controller.text = counterData.$1.toString();
               ultralightCounterControllers.add(controller);
             }
           }
 
-          emulatorSettings =
-              await appState.communicator!.mf0NtagGetEmulatorConfig();
+          emulatorSettings = await _awaitTransport(
+              session, session.communicator.mf0NtagGetEmulatorConfig);
 
           if (emulatorSettings!.isDetectionEnabled) {
-            detectionCount =
-                await appState.communicator!.mf0NtagGetDetectionCount();
+            detectionCount = await _awaitTransport(
+                session, session.communicator.mf0NtagGetDetectionCount);
           }
         }
       } catch (_) {}
     }
 
+    if (!_canContinue(session)) return;
     setState(() {
       previousTagType = selectedType!;
     });
   }
 
-  Future<void> save() async {
-    var appState = Provider.of<ChameleonGUIState>(context, listen: false);
+  Future<bool> save() {
+    return _runSlotOperation(_save);
+  }
 
-    await appState.communicator!.activateSlot(widget.slot);
+  Future<void> _save(ConnectedDeviceSession session) async {
+    await _awaitTransport(
+        session, () => session.communicator.activateSlot(widget.slot));
     if (widget.slotType != selectedType) {
-      await appState.communicator!.setSlotType(widget.slot, selectedType!);
+      await _awaitTransport(session,
+          () => session.communicator.setSlotType(widget.slot, selectedType!));
       bool oldIsClassic = isMifareClassic(widget.slotType);
       bool newIsClassic = isMifareClassic(selectedType!);
       bool oldIsUltralight = isMifareUltralight(widget.slotType);
@@ -196,14 +267,18 @@ class SlotEditMenuState extends State<SlotEditMenu> {
 
       if (!((oldIsClassic && newIsClassic) ||
           (oldIsUltralight && newIsUltralight))) {
-        await appState.communicator!
-            .setDefaultDataToSlot(widget.slot, selectedType!);
+        await _awaitTransport(
+            session,
+            () => session.communicator
+                .setDefaultDataToSlot(widget.slot, selectedType!));
       }
     }
 
     if (isEM410X(selectedType!)) {
-      await appState.communicator!
-          .setEM410XEmulatorID(hexToBytes(uidController.text));
+      await _awaitTransport(
+          session,
+          () => session.communicator
+              .setEM410XEmulatorID(hexToBytes(uidController.text)));
     } else if (selectedType! == TagType.hidProx) {
       try {
         int hidType = int.parse(hidTypeController.text);
@@ -221,18 +296,28 @@ class SlotEditMenuState extends State<SlotEditMenu> {
           oem: oem,
         );
 
-        await appState.communicator!
-            .setHIDProxEmulatorID(hexToBytes(hidCard.toString()));
+        await _awaitTransport(
+            session,
+            () => session.communicator
+                .setHIDProxEmulatorID(hexToBytes(hidCard.toString())));
+      } on _SlotOperationCanceled {
+        rethrow;
       } catch (_) {}
     } else if (selectedType! == TagType.pac) {
-      await appState.communicator!.setPacEmulatorID(
-          hexToBytes(uidController.text.replaceAll(' ', '')));
+      await _awaitTransport(
+          session,
+          () => session.communicator.setPacEmulatorID(
+              hexToBytes(uidController.text.replaceAll(' ', ''))));
     } else if (selectedType! == TagType.ioProx) {
-      await appState.communicator!.setIoProxEmulatorID(
-          hexToBytes(uidController.text.replaceAll(' ', '')));
+      await _awaitTransport(
+          session,
+          () => session.communicator.setIoProxEmulatorID(
+              hexToBytes(uidController.text.replaceAll(' ', ''))));
     } else if (selectedType! == TagType.idteck) {
-      await appState.communicator!.setIdteckEmulatorID(
-          hexToBytes(uidController.text.replaceAll(' ', '')));
+      await _awaitTransport(
+          session,
+          () => session.communicator.setIdteckEmulatorID(
+              hexToBytes(uidController.text.replaceAll(' ', ''))));
     } else if (isMifareClassic(selectedType!) ||
         isMifareUltralight(selectedType!)) {
       var cardData = CardData(
@@ -240,30 +325,39 @@ class SlotEditMenuState extends State<SlotEditMenu> {
           atqa: hexToBytes(atqaController.text),
           sak: bytesToU8(hexToBytes(sakController.text)),
           ats: hexToBytes(atsController.text));
-      await appState.communicator!.setMf1AntiCollision(cardData);
+      await _awaitTransport(
+          session, () => session.communicator.setMf1AntiCollision(cardData));
 
       // Save Ultralight-specific data
       if (isMifareUltralight(selectedType!)) {
-        await appState.communicator!.mf0EmulatorSetVersionData(
-            hexToBytes(ultralightVersionController.text));
+        await _awaitTransport(
+            session,
+            () => session.communicator.mf0EmulatorSetVersionData(
+                hexToBytes(ultralightVersionController.text)));
 
-        await appState.communicator!.mf0EmulatorSetSignatureData(
-            hexToBytes(ultralightSignatureController.text));
+        await _awaitTransport(
+            session,
+            () => session.communicator.mf0EmulatorSetSignatureData(
+                hexToBytes(ultralightSignatureController.text)));
 
         if (mfUltralightHasCounters(selectedType!)) {
           for (int i = 0; i < ultralightCounterControllers.length; i++) {
             int counterValue =
                 int.tryParse(ultralightCounterControllers[i].text) ?? 0;
-            await appState.communicator!
-                .mf0EmulatorSetCounterData(i, counterValue, true);
+            await _awaitTransport(
+                session,
+                () => session.communicator
+                    .mf0EmulatorSetCounterData(i, counterValue, true));
           }
         }
       }
     }
 
-    await appState.communicator!
-        .setSlotTagName(widget.slot, nameController.text, widget.frequency);
-    await appState.communicator!.saveSlotData();
+    await _awaitTransport(
+        session,
+        () => session.communicator.setSlotTagName(
+            widget.slot, nameController.text, widget.frequency));
+    await _awaitTransport(session, session.communicator.saveSlotData);
 
     widget.update(nameController.text, widget.frequency, selectedType);
   }
@@ -480,10 +574,11 @@ class SlotEditMenuState extends State<SlotEditMenu> {
                                                       ? 0
                                                       : 1,
                                               onChange: (int index) async {
-                                                await appState.communicator!
-                                                    .setMf1Gen1aMode(index == 0
-                                                        ? true
-                                                        : false);
+                                                await _runCommand(
+                                                    (communicator) =>
+                                                        communicator
+                                                            .setMf1Gen1aMode(
+                                                                index == 0));
                                               }),
                                           const SizedBox(height: 8),
                                           Text(localizations.mode_gen2),
@@ -498,10 +593,11 @@ class SlotEditMenuState extends State<SlotEditMenu> {
                                                       ? 0
                                                       : 1,
                                               onChange: (int index) async {
-                                                await appState.communicator!
-                                                    .setMf1Gen2Mode(index == 0
-                                                        ? true
-                                                        : false);
+                                                await _runCommand(
+                                                    (communicator) =>
+                                                        communicator
+                                                            .setMf1Gen2Mode(
+                                                                index == 0));
                                               }),
                                           if (mf1PrngType != null) ...[
                                             const SizedBox(height: 8),
@@ -521,8 +617,11 @@ class SlotEditMenuState extends State<SlotEditMenu> {
                                                   setState(() {
                                                     mf1PrngType = nextType;
                                                   });
-                                                  await appState.communicator!
-                                                      .setMf1PrngType(nextType);
+                                                  await _runCommand(
+                                                      (communicator) =>
+                                                          communicator
+                                                              .setMf1PrngType(
+                                                                  nextType));
                                                 }),
                                           ],
                                           const SizedBox(height: 8),
@@ -538,11 +637,10 @@ class SlotEditMenuState extends State<SlotEditMenu> {
                                                       ? 0
                                                       : 1,
                                               onChange: (int index) async {
-                                                await appState.communicator!
-                                                    .setMf1UseFirstBlockColl(
-                                                        index == 0
-                                                            ? true
-                                                            : false);
+                                                await _runCommand(
+                                                    (communicator) => communicator
+                                                        .setMf1UseFirstBlockColl(
+                                                            index == 0));
                                               }),
                                           const SizedBox(height: 8),
                                           Text(localizations
@@ -558,11 +656,10 @@ class SlotEditMenuState extends State<SlotEditMenu> {
                                                   ? 0
                                                   : 1,
                                               onChange: (int index) async {
-                                                await appState.communicator!
-                                                    .setMf1DetectionStatus(
-                                                        index == 0
-                                                            ? true
-                                                            : false);
+                                                await _runCommand(
+                                                    (communicator) => communicator
+                                                        .setMf1DetectionStatus(
+                                                            index == 0));
                                               }),
                                           ...(emulatorSettings!
                                                   .isDetectionEnabled)
@@ -634,27 +731,13 @@ class SlotEditMenuState extends State<SlotEditMenu> {
                                               selectedValue: emulatorSettings!
                                                   .writeMode.value,
                                               onChange: (int index) async {
-                                                if (index == 0) {
-                                                  await appState.communicator!
-                                                      .setMf1WriteMode(
-                                                          MifareWriteMode
-                                                              .normal);
-                                                } else if (index == 1) {
-                                                  await appState.communicator!
-                                                      .setMf1WriteMode(
-                                                          MifareWriteMode
-                                                              .denied);
-                                                } else if (index == 2) {
-                                                  await appState.communicator!
-                                                      .setMf1WriteMode(
-                                                          MifareWriteMode
-                                                              .deceive);
-                                                } else if (index == 3) {
-                                                  await appState.communicator!
-                                                      .setMf1WriteMode(
-                                                          MifareWriteMode
-                                                              .shadow);
-                                                }
+                                                await _runCommand(
+                                                    (communicator) =>
+                                                        communicator
+                                                            .setMf1WriteMode(
+                                                                MifareWriteMode
+                                                                        .values[
+                                                                    index]));
                                               }),
                                         ]),
                                       if (isMifareUltralight(selectedType!) &&
@@ -680,10 +763,11 @@ class SlotEditMenuState extends State<SlotEditMenu> {
                                                       ? 0
                                                       : 1,
                                               onChange: (int index) async {
-                                                await appState.communicator!
-                                                    .mf0SetMagicMode(index == 0
-                                                        ? true
-                                                        : false);
+                                                await _runCommand(
+                                                    (communicator) =>
+                                                        communicator
+                                                            .mf0SetMagicMode(
+                                                                index == 0));
                                               }),
                                           const SizedBox(height: 8),
                                           Text(
@@ -699,11 +783,10 @@ class SlotEditMenuState extends State<SlotEditMenu> {
                                                   ? 0
                                                   : 1,
                                               onChange: (int index) async {
-                                                await appState.communicator!
-                                                    .mf0NtagSetDetectionEnable(
-                                                        index == 0
-                                                            ? true
-                                                            : false);
+                                                await _runCommand(
+                                                    (communicator) => communicator
+                                                        .mf0NtagSetDetectionEnable(
+                                                            index == 0));
                                               }),
                                           ...(emulatorSettings!
                                                   .isDetectionEnabled)
@@ -739,14 +822,14 @@ class SlotEditMenuState extends State<SlotEditMenu> {
                                                                 TextButton(
                                                                     onPressed:
                                                                         () async {
-                                                                      List<String>
-                                                                          passwords =
-                                                                          await appState
-                                                                              .communicator!
-                                                                              .mf0NtagGetDetectionLog(0);
+                                                                      final passwords =
+                                                                          await _runReadCommand((communicator) =>
+                                                                              communicator.mf0NtagGetDetectionLog(0));
 
-                                                                      if (!context
-                                                                          .mounted) {
+                                                                      if (passwords ==
+                                                                              null ||
+                                                                          !context
+                                                                              .mounted) {
                                                                         return;
                                                                       }
 
@@ -821,27 +904,13 @@ class SlotEditMenuState extends State<SlotEditMenu> {
                                               selectedValue: emulatorSettings!
                                                   .writeMode.value,
                                               onChange: (int index) async {
-                                                if (index == 0) {
-                                                  await appState.communicator!
-                                                      .mf0NtagSetWriteMode(
-                                                          MifareWriteMode
-                                                              .normal);
-                                                } else if (index == 1) {
-                                                  await appState.communicator!
-                                                      .mf0NtagSetWriteMode(
-                                                          MifareWriteMode
-                                                              .denied);
-                                                } else if (index == 2) {
-                                                  await appState.communicator!
-                                                      .mf0NtagSetWriteMode(
-                                                          MifareWriteMode
-                                                              .deceive);
-                                                } else if (index == 3) {
-                                                  await appState.communicator!
-                                                      .mf0NtagSetWriteMode(
-                                                          MifareWriteMode
-                                                              .shadow);
-                                                }
+                                                await _runCommand(
+                                                    (communicator) =>
+                                                        communicator
+                                                            .mf0NtagSetWriteMode(
+                                                                MifareWriteMode
+                                                                        .values[
+                                                                    index]));
                                               }),
                                         ]),
                                     ],
@@ -931,7 +1000,9 @@ class SlotEditMenuState extends State<SlotEditMenu> {
               return;
             }
 
-            await save();
+            if (!await save()) {
+              return;
+            }
 
             if (context.mounted) {
               Navigator.pop(context);

--- a/chameleonultragui/lib/gui/menu/dialogs/slot/export.dart
+++ b/chameleonultragui/lib/gui/menu/dialogs/slot/export.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
 
+import 'package:chameleonultragui/bridge/chameleon.dart';
 import 'package:chameleonultragui/gui/component/card_list.dart';
 import 'package:chameleonultragui/gui/component/toggle_buttons.dart';
+import 'package:chameleonultragui/helpers/connected_device_session.dart';
 import 'package:chameleonultragui/helpers/definitions.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/general.dart';
 import 'package:chameleonultragui/helpers/mifare_ultralight/general.dart';
@@ -16,12 +18,14 @@ import 'package:file_picker/file_picker.dart';
 import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
 
 class SlotExportMenu extends StatefulWidget {
+  final int slot;
   final SlotNames names;
   final EnabledSlotInfo enabledSlotInfo;
   final SlotTypes slotTypes;
 
   const SlotExportMenu(
       {super.key,
+      required this.slot,
       required this.names,
       required this.enabledSlotInfo,
       required this.slotTypes});
@@ -34,70 +38,107 @@ class SlotExportMenuState extends State<SlotExportMenu> {
   TagFrequency exportFrequency = TagFrequency.unknown;
 
   Future<CardSave?> rebuildCardSaveFromSlot(TagFrequency frequency) async {
-    var appState = context.read<ChameleonGUIState>();
+    final appState = context.read<ChameleonGUIState>();
+    final result = await appState.runSessionBoundForeground((session) async {
+      bool canContinue() => mounted && session.isCurrent;
+      if (!canContinue()) return null;
+      await session.communicator.activateSlot(widget.slot);
+      if (!canContinue()) return null;
+      return _rebuildCardSaveUnderLease(
+        session.communicator,
+        frequency,
+        canContinue,
+      );
+    });
+    return result.executed ? result.value : null;
+  }
+
+  Future<CardSave?> _rebuildCardSaveUnderLease(
+    ChameleonCommunicator communicator,
+    TagFrequency frequency,
+    bool Function() canContinue,
+  ) async {
+    Future<T?> read<T>(Future<T> Function() operation) async {
+      if (!canContinue()) return null;
+      final value = await operation();
+      return canContinue() ? value : null;
+    }
 
     if (frequency == TagFrequency.lf) {
       if (isEM410X(widget.slotTypes.lf)) {
+        final uid = await read(communicator.getEM410XEmulatorID);
+        if (uid == null) return null;
         return CardSave(
-          uid: bytesToHexSpace(
-              await appState.communicator!.getEM410XEmulatorID()),
+          uid: bytesToHexSpace(uid),
           name: widget.names.lf,
           tag: widget.slotTypes.lf,
         );
       } else if (widget.slotTypes.lf == TagType.hidProx) {
+        final uid = await read(communicator.getHIDProxEmulatorID);
+        if (uid == null) return null;
         return CardSave(
-          uid: (await appState.communicator!.getHIDProxEmulatorID()).toString(),
+          uid: uid.toString(),
           name: widget.names.lf,
           tag: widget.slotTypes.lf,
         );
       } else if (widget.slotTypes.lf == TagType.viking) {
+        final uid = await read(communicator.getVikingEmulatorID);
+        if (uid == null) return null;
         return CardSave(
-          uid: (await appState.communicator!.getVikingEmulatorID()).toString(),
+          uid: uid.toString(),
           name: widget.names.lf,
           tag: widget.slotTypes.lf,
         );
       } else if (widget.slotTypes.lf == TagType.pac) {
+        final uid = await read(communicator.getPacEmulatorID);
+        if (uid == null) return null;
         return CardSave(
-          uid: (await appState.communicator!.getPacEmulatorID()).toString(),
+          uid: uid.toString(),
           name: widget.names.lf,
           tag: widget.slotTypes.lf,
         );
       } else if (widget.slotTypes.lf == TagType.ioProx) {
+        final uid = await read(communicator.getIoProxEmulatorID);
+        if (uid == null) return null;
         return CardSave(
-          uid: (await appState.communicator!.getIoProxEmulatorID()).toString(),
+          uid: uid.toString(),
           name: widget.names.lf,
           tag: widget.slotTypes.lf,
         );
       } else if (widget.slotTypes.lf == TagType.idteck) {
+        final uid = await read(communicator.getIdteckEmulatorID);
+        if (uid == null) return null;
         return CardSave(
-          uid: (await appState.communicator!.getIdteckEmulatorID()).toString(),
+          uid: uid.toString(),
           name: widget.names.lf,
           tag: widget.slotTypes.lf,
         );
       }
     } else {
-      CardData data = await appState.communicator!.mf1GetAntiCollData();
+      final data = await read(communicator.mf1GetAntiCollData);
+      if (data == null) return null;
 
       if (isMifareUltralight(widget.slotTypes.hf)) {
         int pageCount = mfUltralightGetPagesCount(widget.slotTypes.hf);
         List<Uint8List> pages = [];
 
         for (int page = 0; page < pageCount; page++) {
-          Uint8List pageData =
-              await appState.communicator!.mf0EmulatorReadPages(page, 1);
+          final pageData =
+              await read(() => communicator.mf0EmulatorReadPages(page, 1));
+          if (pageData == null) return null;
           pages.add(pageData);
         }
 
         CardSaveExtra extraData = CardSaveExtra();
 
-        Uint8List version =
-            await appState.communicator!.mf0EmulatorGetVersionData();
+        final version = await read(communicator.mf0EmulatorGetVersionData);
+        if (version == null) return null;
         if (version.isNotEmpty) {
           extraData.ultralightVersion = version;
         }
 
-        Uint8List signature =
-            await appState.communicator!.mf0EmulatorGetSignatureData();
+        final signature = await read(communicator.mf0EmulatorGetSignatureData);
+        if (signature == null) return null;
         if (signature.isNotEmpty) {
           extraData.ultralightSignature = signature;
         }
@@ -107,8 +148,9 @@ class SlotExportMenuState extends State<SlotExportMenu> {
           int counterCount = mfUltralightGetCounterCount(widget.slotTypes.hf);
 
           for (int i = 0; i < counterCount; i++) {
-            var counterData =
-                await appState.communicator!.mf0EmulatorGetCounterData(i);
+            final counterData =
+                await read(() => communicator.mf0EmulatorGetCounterData(i));
+            if (counterData == null) return null;
             counters.add(counterData.$1);
           }
 
@@ -139,8 +181,9 @@ class SlotExportMenuState extends State<SlotExportMenu> {
         for (int currentBlock = 0;
             currentBlock < blockCount;
             currentBlock += readCount) {
-          Uint8List result = await appState.communicator!
-              .mf1GetEmulatorBlock(currentBlock, readCount);
+          final result = await read(
+              () => communicator.mf1GetEmulatorBlock(currentBlock, readCount));
+          if (result == null) return null;
 
           binData.setAll(binDataIndex, result);
           binDataIndex += result.length;
@@ -149,8 +192,9 @@ class SlotExportMenuState extends State<SlotExportMenu> {
         int remainingBlocks = blockCount % readCount;
 
         if (remainingBlocks != 0) {
-          Uint8List result = await appState.communicator!.mf1GetEmulatorBlock(
-              blockCount - remainingBlocks, remainingBlocks);
+          final result = await read(() => communicator.mf1GetEmulatorBlock(
+              blockCount - remainingBlocks, remainingBlocks));
+          if (result == null) return null;
           binData.setAll(binDataIndex, result);
         }
 

--- a/chameleonultragui/lib/gui/menu/dialogs/slot/settings.dart
+++ b/chameleonultragui/lib/gui/menu/dialogs/slot/settings.dart
@@ -1,6 +1,7 @@
 import 'package:chameleonultragui/gui/component/error_page.dart';
 import 'package:chameleonultragui/gui/menu/dialogs/slot/edit.dart';
 import 'package:chameleonultragui/gui/menu/dialogs/slot/export.dart';
+import 'package:chameleonultragui/helpers/connected_device_session.dart';
 import 'package:chameleonultragui/helpers/definitions.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -32,37 +33,73 @@ class SlotSettingsState extends State<SlotSettings> {
   }
 
   Future<void> fetchInfo() async {
-    var appState = context.read<ChameleonGUIState>();
-    var localizations = AppLocalizations.of(context)!;
+    final appState = context.read<ChameleonGUIState>();
+    final localizations = AppLocalizations.of(context)!;
+    await appState.runSessionBoundForeground((session) async {
+      bool canContinue() => mounted && session.isCurrent;
+      if (!canContinue()) return;
+      await session.communicator.activateSlot(widget.slot);
+      if (!canContinue()) return;
 
-    await appState.communicator!.activateSlot(widget.slot);
-
-    try {
-      String name = (await appState.communicator!
-              .getSlotTagName(widget.slot, TagFrequency.hf))
-          .trim();
-      if (name.isEmpty) {
-        names.hf = localizations.empty;
-      } else {
-        names.hf = name;
+      var hfName = localizations.empty;
+      try {
+        hfName = (await session.communicator
+                .getSlotTagName(widget.slot, TagFrequency.hf))
+            .trim();
+        if (!canContinue()) return;
+        if (hfName.isEmpty) hfName = localizations.empty;
+      } catch (_) {
+        if (!canContinue()) return;
       }
-    } catch (_) {}
 
-    try {
-      String name = (await appState.communicator!
-              .getSlotTagName(widget.slot, TagFrequency.lf))
-          .trim();
-      if (name.isEmpty) {
-        names.lf = localizations.empty;
-      } else {
-        names.lf = name;
+      var lfName = localizations.empty;
+      try {
+        lfName = (await session.communicator
+                .getSlotTagName(widget.slot, TagFrequency.lf))
+            .trim();
+        if (!canContinue()) return;
+        if (lfName.isEmpty) lfName = localizations.empty;
+      } catch (_) {
+        if (!canContinue()) return;
       }
-    } catch (_) {}
 
-    enabledSlot = (await appState.communicator!.getEnabledSlots())[widget.slot];
-    slotTypes = (await appState.communicator!.getSlotTagTypes())[widget.slot];
+      final nextEnabledSlots = await session.communicator.getEnabledSlots();
+      if (!canContinue()) return;
+      final nextSlotTypes = await session.communicator.getSlotTagTypes();
+      if (!canContinue()) return;
 
-    setState(() {});
+      setState(() {
+        names = SlotNames(hf: hfName, lf: lfName);
+        enabledSlot = nextEnabledSlots[widget.slot];
+        slotTypes = nextSlotTypes[widget.slot];
+      });
+    });
+  }
+
+  Future<bool> _runForegroundCommand(
+    Future<void> Function(ConnectedDeviceSession session) command,
+  ) async {
+    final appState = context.read<ChameleonGUIState>();
+    final result = await appState.runSessionBoundForeground((session) async {
+      if (!mounted || !session.isCurrent) return false;
+      await command(session);
+      return mounted && session.isCurrent;
+    });
+    return result.executed && result.value == true;
+  }
+
+  Future<bool> _deleteSlot(TagFrequency frequency) {
+    final emptyName = AppLocalizations.of(context)!.empty;
+    return _runForegroundCommand((session) async {
+      await session.communicator.activateSlot(widget.slot);
+      if (!mounted || !session.isCurrent) return;
+      await session.communicator.deleteSlotInfo(widget.slot, frequency);
+      if (!mounted || !session.isCurrent) return;
+      await session.communicator
+          .setSlotTagName(widget.slot, emptyName, frequency);
+      if (!mounted || !session.isCurrent) return;
+      await session.communicator.saveSlotData();
+    });
   }
 
   void updateSlot(String name, TagFrequency frequency, TagType type) {
@@ -113,6 +150,7 @@ class SlotSettingsState extends State<SlotSettings> {
                                   context: context,
                                   builder: (BuildContext context) =>
                                       SlotExportMenu(
+                                          slot: widget.slot,
                                           names: names,
                                           enabledSlotInfo: enabledSlot,
                                           slotTypes: slotTypes));
@@ -163,13 +201,9 @@ class SlotSettingsState extends State<SlotSettings> {
                                   return;
                                 }
                               }
-                              await appState.communicator!
-                                  .deleteSlotInfo(widget.slot, TagFrequency.hf);
-                              await appState.communicator!.setSlotTagName(
-                                  widget.slot,
-                                  localizations.empty,
-                                  TagFrequency.hf);
-                              await appState.communicator!.saveSlotData();
+                              if (!await _deleteSlot(TagFrequency.hf)) {
+                                return;
+                              }
 
                               setState(() {
                                 names.hf = localizations.empty;
@@ -183,8 +217,14 @@ class SlotSettingsState extends State<SlotSettings> {
                           Switch(
                             value: enabledSlot.hf,
                             onChanged: (bool value) async {
-                              await appState.communicator!.enableSlot(
-                                  widget.slot, TagFrequency.hf, value);
+                              if (!await _runForegroundCommand(
+                                  (session) => session.communicator.enableSlot(
+                                        widget.slot,
+                                        TagFrequency.hf,
+                                        value,
+                                      ))) {
+                                return;
+                              }
 
                               setState(() {
                                 enabledSlot.hf = value;
@@ -248,13 +288,9 @@ class SlotSettingsState extends State<SlotSettings> {
                                   return;
                                 }
                               }
-                              await appState.communicator!
-                                  .deleteSlotInfo(widget.slot, TagFrequency.lf);
-                              await appState.communicator!.setSlotTagName(
-                                  widget.slot,
-                                  localizations.empty,
-                                  TagFrequency.lf);
-                              await appState.communicator!.saveSlotData();
+                              if (!await _deleteSlot(TagFrequency.lf)) {
+                                return;
+                              }
 
                               setState(() {
                                 names.lf = localizations.empty;
@@ -268,8 +304,14 @@ class SlotSettingsState extends State<SlotSettings> {
                           Switch(
                             value: enabledSlot.lf,
                             onChanged: (bool value) async {
-                              await appState.communicator!.enableSlot(
-                                  widget.slot, TagFrequency.lf, value);
+                              if (!await _runForegroundCommand(
+                                  (session) => session.communicator.enableSlot(
+                                        widget.slot,
+                                        TagFrequency.lf,
+                                        value,
+                                      ))) {
+                                return;
+                              }
 
                               setState(() {
                                 enabledSlot.lf = value;

--- a/chameleonultragui/lib/gui/menu/tools/hf_sniffing.dart
+++ b/chameleonultragui/lib/gui/menu/tools/hf_sniffing.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
 import 'package:chameleonultragui/gui/component/hex_viewer.dart';
 import 'package:chameleonultragui/gui/menu/dialogs/dictionary/export.dart';
+import 'package:chameleonultragui/helpers/connected_device_session.dart';
 import 'package:chameleonultragui/helpers/definitions.dart';
 import 'package:chameleonultragui/helpers/general.dart';
 import 'package:chameleonultragui/helpers/hf_sniff.dart';
@@ -67,26 +68,19 @@ class _HfSniffingMenuState extends State<HfSniffingMenu> {
 
   Future<void> _loadCapabilities() async {
     final appState = context.read<ChameleonGUIState>();
-    if (appState.communicator == null) {
+    final result = await appState.runSessionBoundForegroundCatching(
+      (session) async {
+        final capabilities = await session.communicator.getDeviceCapabilities();
+        return capabilities.contains(ChameleonCommand.hf14aSniff.value);
+      },
+    );
+    final session = result.session;
+    if (!result.executed || session == null || !mounted || !session.isCurrent) {
       return;
     }
-    try {
-      final capabilities = await appState.communicator!.getDeviceCapabilities();
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _capabilitySupported =
-            capabilities.contains(ChameleonCommand.hf14aSniff.value);
-      });
-    } catch (_) {
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _capabilitySupported = null;
-      });
-    }
+    setState(() {
+      _capabilitySupported = result.error == null ? result.value : null;
+    });
   }
 
   Future<void> _captureFrames() async {
@@ -107,15 +101,51 @@ class _HfSniffingMenuState extends State<HfSniffingMenu> {
     });
 
     try {
-      if (await appState.communicator!.isReaderDeviceMode()) {
-        await appState.communicator!.setReaderDeviceMode(false);
-      }
+      final result =
+          await appState.runSessionBoundForegroundCatching((session) async {
+        if (!mounted || !session.isCurrent) {
+          return null;
+        }
 
-      final rawBytes =
-          await appState.communicator!.hf14aSniff(timeoutMs: timeoutMs);
-      if (!mounted) {
+        if (await session.communicator.isReaderDeviceMode()) {
+          if (!mounted || !session.isCurrent) {
+            return null;
+          }
+          await session.communicator.setReaderDeviceMode(false);
+        }
+        if (!mounted || !session.isCurrent) {
+          return null;
+        }
+
+        final rawBytes =
+            await session.communicator.hf14aSniff(timeoutMs: timeoutMs);
+        return mounted && session.isCurrent ? rawBytes : null;
+      });
+      final session = result.session;
+      final rawBytes = result.value;
+      if (!result.executed ||
+          session == null ||
+          !mounted ||
+          !session.isCurrent) {
         return;
       }
+
+      final error = result.error;
+      if (error != null) {
+        final errorText = error.toString();
+        final firmwareUnsupported = _isFirmwareUnsupportedError(errorText);
+        setState(() {
+          if (firmwareUnsupported) {
+            _capabilitySupported = false;
+            _statusMessage = null;
+            _errorMessage = null;
+          } else {
+            _errorMessage = errorText;
+          }
+        });
+        return;
+      }
+      if (rawBytes == null) return;
 
       if (rawBytes.isEmpty) {
         setState(() {
@@ -130,22 +160,6 @@ class _HfSniffingMenuState extends State<HfSniffingMenu> {
         _statusMessage = capture.frames.isEmpty
             ? localizations.hf_sniff_no_decoded_frames
             : localizations.hf_sniff_capture_done(capture.frames.length);
-      });
-    } catch (error) {
-      if (!mounted) {
-        return;
-      }
-
-      final errorText = error.toString();
-      final firmwareUnsupported = _isFirmwareUnsupportedError(errorText);
-      setState(() {
-        if (firmwareUnsupported) {
-          _capabilitySupported = false;
-          _statusMessage = null;
-          _errorMessage = null;
-        } else {
-          _errorMessage = errorText;
-        }
       });
     } finally {
       if (mounted) {
@@ -209,8 +223,8 @@ class _HfSniffingMenuState extends State<HfSniffingMenu> {
         return;
       }
       setState(() {
-        _errorMessage =
-            localizations.hf_sniff_load_failed(localizations.hf_sniff_no_frames);
+        _errorMessage = localizations
+            .hf_sniff_load_failed(localizations.hf_sniff_no_frames);
       });
       return;
     }

--- a/chameleonultragui/lib/gui/menu/tools/lf_sniffing.dart
+++ b/chameleonultragui/lib/gui/menu/tools/lf_sniffing.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 
 import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
 import 'package:chameleonultragui/gui/component/hex_viewer.dart';
+import 'package:chameleonultragui/helpers/connected_device_session.dart';
 import 'package:chameleonultragui/helpers/definitions.dart';
 import 'package:chameleonultragui/helpers/lf_sniff.dart';
 import 'package:chameleonultragui/helpers/validators.dart';
@@ -54,26 +55,19 @@ class _LfSniffingMenuState extends State<LfSniffingMenu> {
 
   Future<void> _loadCapabilities() async {
     final appState = context.read<ChameleonGUIState>();
-    if (appState.communicator == null) {
+    final result = await appState.runSessionBoundForegroundCatching(
+      (session) async {
+        final capabilities = await session.communicator.getDeviceCapabilities();
+        return capabilities.contains(ChameleonCommand.lfSniff.value);
+      },
+    );
+    final session = result.session;
+    if (!result.executed || session == null || !mounted || !session.isCurrent) {
       return;
     }
-    try {
-      final capabilities = await appState.communicator!.getDeviceCapabilities();
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _capabilitySupported =
-            capabilities.contains(ChameleonCommand.lfSniff.value);
-      });
-    } catch (_) {
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _capabilitySupported = null;
-      });
-    }
+    setState(() {
+      _capabilitySupported = result.error == null ? result.value : null;
+    });
   }
 
   bool _isDeviceConnected() {
@@ -96,15 +90,51 @@ class _LfSniffingMenuState extends State<LfSniffingMenu> {
     });
 
     try {
-      if (!await appState.communicator!.isReaderDeviceMode()) {
-        await appState.communicator!.setReaderDeviceMode(true);
-      }
+      final result =
+          await appState.runSessionBoundForegroundCatching((session) async {
+        if (!mounted || !session.isCurrent) {
+          return null;
+        }
 
-      final samples =
-          await appState.communicator!.lfSniff(timeoutMs: timeoutMs);
-      if (!mounted) {
+        if (!await session.communicator.isReaderDeviceMode()) {
+          if (!mounted || !session.isCurrent) {
+            return null;
+          }
+          await session.communicator.setReaderDeviceMode(true);
+        }
+        if (!mounted || !session.isCurrent) {
+          return null;
+        }
+
+        final samples =
+            await session.communicator.lfSniff(timeoutMs: timeoutMs);
+        return mounted && session.isCurrent ? samples : null;
+      });
+      final session = result.session;
+      final samples = result.value;
+      if (!result.executed ||
+          session == null ||
+          !mounted ||
+          !session.isCurrent) {
         return;
       }
+
+      final error = result.error;
+      if (error != null) {
+        final errorText = error.toString();
+        final firmwareUnsupported = _isFirmwareUnsupportedError(errorText);
+        setState(() {
+          if (firmwareUnsupported) {
+            _capabilitySupported = false;
+            _statusMessage = null;
+            _errorMessage = null;
+          } else {
+            _errorMessage = errorText;
+          }
+        });
+        return;
+      }
+      if (samples == null) return;
 
       if (samples.isEmpty) {
         setState(() {
@@ -125,22 +155,6 @@ class _LfSniffingMenuState extends State<LfSniffingMenu> {
         _decodeError = decodeOutcome.error;
         _statusMessage =
             localizations.lf_sniff_capture_done(capture.summary.sampleCount);
-      });
-    } catch (error) {
-      if (!mounted) {
-        return;
-      }
-
-      final errorText = error.toString();
-      final firmwareUnsupported = _isFirmwareUnsupportedError(errorText);
-      setState(() {
-        if (firmwareUnsupported) {
-          _capabilitySupported = false;
-          _statusMessage = null;
-          _errorMessage = null;
-        } else {
-          _errorMessage = errorText;
-        }
       });
     } finally {
       if (mounted) {
@@ -221,8 +235,8 @@ class _LfSniffingMenuState extends State<LfSniffingMenu> {
         return;
       }
       setState(() {
-        _errorMessage =
-            localizations.lf_sniff_load_failed(localizations.lf_sniff_no_samples);
+        _errorMessage = localizations
+            .lf_sniff_load_failed(localizations.lf_sniff_no_samples);
       });
       return;
     }
@@ -245,8 +259,8 @@ class _LfSniffingMenuState extends State<LfSniffingMenu> {
         return;
       }
       setState(() {
-        _errorMessage =
-            localizations.lf_sniff_load_failed(localizations.lf_sniff_no_samples);
+        _errorMessage = localizations
+            .lf_sniff_load_failed(localizations.lf_sniff_no_samples);
       });
       return;
     }

--- a/chameleonultragui/lib/gui/menu/tools/t55xx_password_cleaner.dart
+++ b/chameleonultragui/lib/gui/menu/tools/t55xx_password_cleaner.dart
@@ -1,5 +1,6 @@
 import 'package:chameleonultragui/gui/component/error_page.dart';
 import 'package:chameleonultragui/gui/menu/tools/dictionary_download.dart';
+import 'package:chameleonultragui/helpers/connected_device_session.dart';
 import 'package:chameleonultragui/helpers/general.dart';
 import 'package:chameleonultragui/helpers/validators.dart';
 import 'package:chameleonultragui/main.dart';
@@ -47,6 +48,7 @@ class T55XXPasswordCleanerMenuState extends State<T55XXPasswordCleanerMenu> {
     Dictionary? selectedDictionary =
         dictionaries.where((d) => d.id == selectedDictionaryId).firstOrNull;
     if (selectedDictionary == null) return;
+    final newKey = hexToBytes(newKeyController.text);
 
     setState(() {
       isProcessing = true;
@@ -56,8 +58,15 @@ class T55XXPasswordCleanerMenuState extends State<T55XXPasswordCleanerMenu> {
     });
 
     var localizations = AppLocalizations.of(context)!;
+    var sessionCancelled = false;
 
-    try {
+    final result =
+        await appState.runSessionBoundForegroundCatching((session) async {
+      if (!mounted || !session.isCurrent) {
+        sessionCancelled = true;
+        return;
+      }
+
       String targetUID = "DE AD BE EF FF";
 
       for (int i = 0; i < selectedDictionary.keys.length; i++) {
@@ -68,44 +77,76 @@ class T55XXPasswordCleanerMenuState extends State<T55XXPasswordCleanerMenu> {
           currentKey = bytesToHexSpace(selectedDictionary.keys[i]);
         });
 
+        var writeIssued = false;
         try {
-          await appState.communicator!.writeEM410XtoT55XX(hexToBytes(targetUID),
-              hexToBytes(newKeyController.text), [selectedDictionary.keys[i]]);
+          writeIssued = true;
+          await session.communicator.writeEM410XtoT55XX(
+              hexToBytes(targetUID), newKey, [selectedDictionary.keys[i]]);
+          if (!mounted || !session.isCurrent) {
+            sessionCancelled = true;
+            return;
+          }
 
-          var newCard = await appState.communicator!.readEM410X();
+          var newCard = await session.communicator.readEM410X();
+          if (!mounted || !session.isCurrent) {
+            sessionCancelled = true;
+            return;
+          }
+          if (newCard == null) {
+            throw StateError('Password reset write outcome is unknown');
+          }
+          writeIssued = false;
 
-          if (newCard != null && newCard.toString() == targetUID) {
+          if (newCard.toString() == targetUID) {
             setState(() {
               foundPassword = bytesToHexSpace(selectedDictionary.keys[i]);
               isProcessing = false;
             });
 
-            if (mounted) {
-              showSuccessDialog(localizations, foundPassword!);
-            }
+            showSuccessDialog(localizations, foundPassword!);
             return;
           }
-        } catch (e) {
+        } catch (_) {
+          if (!mounted || !session.isCurrent) {
+            sessionCancelled = true;
+            return;
+          }
+          if (writeIssued) rethrow;
           continue;
         }
       }
+    });
+    final session = result.session;
 
-      if (isProcessing) {
+    if (!result.executed ||
+        session == null ||
+        sessionCancelled ||
+        !mounted ||
+        !session.isCurrent) {
+      if (mounted) {
         setState(() {
           isProcessing = false;
         });
-
-        if (mounted) {
-          showFailureDialog(localizations);
-        }
       }
-    } catch (e) {
+      return;
+    }
+
+    final error = result.error;
+    if (error != null) {
+      setState(() {
+        isProcessing = false;
+      });
+      showErrorDialog(error.toString());
+      return;
+    }
+
+    if (isProcessing) {
       setState(() {
         isProcessing = false;
       });
 
       if (mounted) {
-        showErrorDialog(e.toString());
+        showFailureDialog(localizations);
       }
     }
   }

--- a/chameleonultragui/lib/gui/page/home.dart
+++ b/chameleonultragui/lib/gui/page/home.dart
@@ -1,5 +1,6 @@
 import 'package:chameleonultragui/gui/component/error_page.dart';
 import 'package:chameleonultragui/gui/menu/dialogs/chameleon_settings.dart';
+import 'package:chameleonultragui/helpers/connected_device_session.dart';
 import 'package:chameleonultragui/helpers/definitions.dart';
 import 'package:chameleonultragui/helpers/flash.dart';
 import 'package:chameleonultragui/helpers/general.dart';
@@ -202,6 +203,21 @@ class HomePageState extends State<HomePage> {
   Future<bool> isReaderDeviceMode() async {
     var appState = context.read<ChameleonGUIState>();
     return await appState.communicator!.isReaderDeviceMode();
+  }
+
+  Future<void> _setReaderDeviceMode(bool readerMode) async {
+    final appState = context.read<ChameleonGUIState>();
+    await appState.runSessionBoundForeground((session) async {
+      if (!mounted || !session.isCurrent) {
+        return;
+      }
+      await session.communicator.setReaderDeviceMode(readerMode);
+      if (!mounted || !session.isCurrent) {
+        return;
+      }
+      setState(() {});
+      appState.changesMade();
+    });
   }
 
   @override
@@ -539,10 +555,7 @@ class HomePageState extends State<HomePage> {
                                   padding: const EdgeInsets.all(8.0),
                                   child: IconButton(
                                     onPressed: () async {
-                                      await appState.communicator!
-                                          .setReaderDeviceMode(false);
-                                      setState(() {});
-                                      appState.changesMade();
+                                      await _setReaderDeviceMode(false);
                                     },
                                     tooltip: localizations.emulator_mode,
                                     icon: const Icon(Icons.nfc_sharp),
@@ -552,10 +565,7 @@ class HomePageState extends State<HomePage> {
                                   padding: const EdgeInsets.all(8.0),
                                   child: IconButton(
                                     onPressed: () async {
-                                      await appState.communicator!
-                                          .setReaderDeviceMode(true);
-                                      setState(() {});
-                                      appState.changesMade();
+                                      await _setReaderDeviceMode(true);
                                     },
                                     tooltip: localizations.reader_mode,
                                     icon: const Icon(Icons.barcode_reader),

--- a/chameleonultragui/lib/gui/page/home.dart
+++ b/chameleonultragui/lib/gui/page/home.dart
@@ -25,52 +25,91 @@ class HomePage extends StatefulWidget {
 class HomePageState extends State<HomePage> {
   int selectedSlot = 1;
   bool isLegacyFirmware = false;
+  Future<_HomeStatusData?>? _statusFuture;
+  Object? _statusConnector;
+  Object? _statusCommunicator;
 
   @override
   void initState() {
     super.initState();
   }
 
-  Future<((Icon, BatteryCharge), String, List<String>, bool, bool)>
-      getFutureData() async {
-    var appState = context.read<ChameleonGUIState>();
-    List<SlotTypes> slotTypes = [];
-    try {
-      slotTypes = await appState.communicator!.getSlotTagTypes();
-    } catch (e) {
-      appState.log!.e(e);
+  Future<_HomeStatusData?> _getFutureData() async {
+    final appState = context.read<ChameleonGUIState>();
+    final result = await appState
+        .runSessionBoundForegroundCatching<_HomeStatusData>((session) async {
+      _ensureCurrent(session);
+
+      List<SlotTypes> slotTypes = [];
+      try {
+        slotTypes = await session.communicator.getSlotTagTypes();
+      } catch (error) {
+        appState.log!.e(error);
+      }
+      _ensureCurrent(session);
+
+      final batteryInfo = await _getBatteryInfo(session);
+      final version = await _getVersion(session);
+      final readerDeviceMode = await _isReaderDeviceMode(session);
+      final capabilitiesSupported = await _areCapabilitiesSupported(session);
+      _ensureCurrent(session);
+
+      return _HomeStatusData(
+        batteryInfo: batteryInfo,
+        usedSlots: _getUsedSlotsOut8(slotTypes),
+        firmwareVersion: version.$1,
+        readerDeviceMode: readerDeviceMode,
+        capabilitiesSupported: capabilitiesSupported,
+        legacyFirmware: version.$2,
+      );
+    });
+
+    if (!result.executed ||
+        result.error is _StaleHomeStatus ||
+        result.session?.isCurrent != true ||
+        !mounted) {
+      return null;
+    }
+    if (result.error != null) {
+      Error.throwWithStackTrace(result.error!, result.stackTrace!);
     }
 
-    return (
-      await getBatteryInfo(),
-      await getUsedSlotsOut8(slotTypes),
-      await getVersion(),
-      await isReaderDeviceMode(),
-      await areCapabilitiesSupported()
-    );
+    final data = result.value!;
+    isLegacyFirmware = data.legacyFirmware;
+    if (isLegacyFirmware) {
+      _showLegacyFirmwareDialog(appState);
+    }
+    return data;
   }
 
-  Future<bool> areCapabilitiesSupported() async {
+  void _ensureCurrent(ConnectedDeviceSession session) {
+    if (!mounted || !session.isCurrent) {
+      throw const _StaleHomeStatus();
+    }
+  }
+
+  Future<bool> _areCapabilitiesSupported(ConnectedDeviceSession session) async {
     // Checks that firmware supports all functions of current app
     // If not, prompt user to update firmware (as outdated firmware might break app)
 
     int ultraCapability = ChameleonCommand.setIdteckEmulatorID.value;
     int liteCapability = ChameleonCommand.setIdteckEmulatorID.value;
 
-    var appState = context.read<ChameleonGUIState>();
     List<int> capabilities;
     try {
-      capabilities = await appState.communicator!.getDeviceCapabilities();
+      capabilities = await session.communicator.getDeviceCapabilities();
     } catch (_) {
+      _ensureCurrent(session);
       return false;
     }
+    _ensureCurrent(session);
 
-    if (appState.connector!.device == ChameleonDevice.ultra &&
+    if (session.connector.device == ChameleonDevice.ultra &&
         !capabilities.contains(ultraCapability)) {
       return false;
     }
 
-    if (appState.connector!.device == ChameleonDevice.lite &&
+    if (session.connector.device == ChameleonDevice.lite &&
         !capabilities.contains(liteCapability)) {
       return false;
     }
@@ -78,14 +117,15 @@ class HomePageState extends State<HomePage> {
     return true;
   }
 
-  Future<(Icon, BatteryCharge)> getBatteryInfo() async {
-    var appState = context.read<ChameleonGUIState>();
+  Future<(Icon, BatteryCharge)> _getBatteryInfo(
+      ConnectedDeviceSession session) async {
     var icon = const Icon(Icons.battery_unknown);
     BatteryCharge battery = BatteryCharge(percent: 0, voltage: 0);
 
     try {
-      battery = await appState.communicator!.getBatteryCharge();
+      battery = await session.communicator.getBatteryCharge();
     } catch (_) {}
+    _ensureCurrent(session);
 
     if (battery.percent > 98) {
       icon = const Icon(Icons.battery_full);
@@ -110,7 +150,7 @@ class HomePageState extends State<HomePage> {
     return (icon, battery);
   }
 
-  Future<String> getUsedSlotsOut8(List<SlotTypes> slotTypes) async {
+  String _getUsedSlotsOut8(List<SlotTypes> slotTypes) {
     int usedSlotsOut8 = 0;
 
     if (slotTypes.isEmpty) {
@@ -125,17 +165,17 @@ class HomePageState extends State<HomePage> {
     return usedSlotsOut8.toString();
   }
 
-  Future<List<String>> getVersion() async {
-    var appState = context.read<ChameleonGUIState>();
-
+  Future<(List<String>, bool)> _getVersion(
+      ConnectedDeviceSession session) async {
     String commitHash = "";
-    var firmware = await appState.communicator!.getFirmwareVersion();
-    isLegacyFirmware = firmware.legacyProtocol;
+    var firmware = await session.communicator.getFirmwareVersion();
+    _ensureCurrent(session);
     String firmwareVersion = numToVerCode(firmware.version);
 
     try {
-      commitHash = await appState.communicator!.getGitCommitHash();
+      commitHash = await session.communicator.getGitCommitHash();
     } catch (_) {}
+    _ensureCurrent(session);
 
     if (commitHash.isEmpty) {
       if (mounted) {
@@ -145,64 +185,68 @@ class HomePageState extends State<HomePage> {
       }
     }
 
-    if (mounted && isLegacyFirmware) {
-      var localizations = AppLocalizations.of(context)!;
-      showDialog<void>(
-        context: context,
-        barrierDismissible: false,
-        builder: (BuildContext context) {
-          return AlertDialog(
-            title: Text(localizations.outdated_protocol),
-            content: SingleChildScrollView(
-              child: ListBody(
-                children: <Widget>[
-                  Text(localizations.outdated_protocol_description_1),
-                  Text(localizations.outdated_protocol_description_2),
-                  Text(localizations.outdated_protocol_description_3),
-                ],
-              ),
-            ),
-            actions: <Widget>[
-              TextButton(
-                child: Text(localizations.update),
-                onPressed: () async {
-                  Navigator.of(context).pop();
-                  var localizations = AppLocalizations.of(context)!;
-                  var scaffoldMessenger = ScaffoldMessenger.of(context);
-                  var snackBar = SnackBar(
-                    content: Text(localizations.downloading_fw(
-                        chameleonDeviceName(appState.connector!.device))),
-                    action: SnackBarAction(
-                      label: localizations.close,
-                      onPressed: () {
-                        scaffoldMessenger.hideCurrentSnackBar();
-                      },
-                    ),
-                  );
-
-                  scaffoldMessenger.showSnackBar(snackBar);
-                  await flashFirmware(appState,
-                      scaffoldMessenger: scaffoldMessenger);
-                },
-              ),
-              TextButton(
-                child: Text(localizations.skip),
-                onPressed: () {
-                  Navigator.of(context).pop();
-                },
-              ),
-            ],
-          );
-        },
-      );
-    }
-
-    return ["$firmwareVersion ($commitHash)", commitHash];
+    return (
+      ["$firmwareVersion ($commitHash)", commitHash],
+      firmware.legacyProtocol
+    );
   }
 
-  Future<bool> isReaderDeviceMode() async {
-    var appState = context.read<ChameleonGUIState>();
-    return await appState.communicator!.isReaderDeviceMode();
+  Future<bool> _isReaderDeviceMode(ConnectedDeviceSession session) async {
+    final readerDeviceMode = await session.communicator.isReaderDeviceMode();
+    _ensureCurrent(session);
+    return readerDeviceMode;
+  }
+
+  void _showLegacyFirmwareDialog(ChameleonGUIState appState) {
+    var localizations = AppLocalizations.of(context)!;
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text(localizations.outdated_protocol),
+          content: SingleChildScrollView(
+            child: ListBody(
+              children: <Widget>[
+                Text(localizations.outdated_protocol_description_1),
+                Text(localizations.outdated_protocol_description_2),
+                Text(localizations.outdated_protocol_description_3),
+              ],
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+              child: Text(localizations.update),
+              onPressed: () async {
+                Navigator.of(context).pop();
+                var localizations = AppLocalizations.of(context)!;
+                var scaffoldMessenger = ScaffoldMessenger.of(context);
+                var snackBar = SnackBar(
+                  content: Text(localizations.downloading_fw(
+                      chameleonDeviceName(appState.connector!.device))),
+                  action: SnackBarAction(
+                    label: localizations.close,
+                    onPressed: () {
+                      scaffoldMessenger.hideCurrentSnackBar();
+                    },
+                  ),
+                );
+
+                scaffoldMessenger.showSnackBar(snackBar);
+                await flashFirmware(appState,
+                    scaffoldMessenger: scaffoldMessenger);
+              },
+            ),
+            TextButton(
+              child: Text(localizations.skip),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
   }
 
   Future<void> _setReaderDeviceMode(bool readerMode) async {
@@ -215,20 +259,33 @@ class HomePageState extends State<HomePage> {
       if (!mounted || !session.isCurrent) {
         return;
       }
-      setState(() {});
+      setState(() {
+        _statusConnector = appState.connector;
+        _statusCommunicator = appState.communicator;
+        _statusFuture = _getFutureData();
+      });
       appState.changesMade();
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    var appState = context.read<ChameleonGUIState>();
+    var appState = context.watch<ChameleonGUIState>();
     var localizations = AppLocalizations.of(context)!;
     var scaffoldMessenger = ScaffoldMessenger.of(context);
-    return FutureBuilder(
-        future: getFutureData(),
-        builder: (BuildContext context, AsyncSnapshot snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
+    if (_statusFuture == null ||
+        !identical(_statusConnector, appState.connector) ||
+        !identical(_statusCommunicator, appState.communicator)) {
+      _statusConnector = appState.connector;
+      _statusCommunicator = appState.communicator;
+      _statusFuture = _getFutureData();
+    }
+    return FutureBuilder<_HomeStatusData?>(
+        future: _statusFuture,
+        builder:
+            (BuildContext context, AsyncSnapshot<_HomeStatusData?> snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting ||
+              (!snapshot.hasError && snapshot.data == null)) {
             return Scaffold(
               appBar: AppBar(
                 title: Text(localizations.home),
@@ -236,7 +293,6 @@ class HomePageState extends State<HomePage> {
               body: const Center(child: CircularProgressIndicator()),
             );
           } else if (snapshot.hasError) {
-            appState.disconnect();
             return Scaffold(
               appBar: AppBar(
                 title: Text(localizations.home),
@@ -245,13 +301,12 @@ class HomePageState extends State<HomePage> {
                   child: ErrorPage(errorMessage: snapshot.error.toString())),
             );
           } else {
-            final (
-              batteryInfo,
-              usedSlots,
-              fwVersion,
-              isReaderDeviceMode,
-              areCapabilitiesSupported,
-            ) = snapshot.data;
+            final data = snapshot.data!;
+            final batteryInfo = data.batteryInfo;
+            final usedSlots = data.usedSlots;
+            final fwVersion = data.firmwareVersion;
+            final isReaderDeviceMode = data.readerDeviceMode;
+            final areCapabilitiesSupported = data.capabilitiesSupported;
 
             return Scaffold(
               appBar: AppBar(
@@ -591,4 +646,26 @@ class HomePageState extends State<HomePage> {
           }
         });
   }
+}
+
+class _HomeStatusData {
+  const _HomeStatusData({
+    required this.batteryInfo,
+    required this.usedSlots,
+    required this.firmwareVersion,
+    required this.readerDeviceMode,
+    required this.capabilitiesSupported,
+    required this.legacyFirmware,
+  });
+
+  final (Icon, BatteryCharge) batteryInfo;
+  final String usedSlots;
+  final List<String> firmwareVersion;
+  final bool readerDeviceMode;
+  final bool capabilitiesSupported;
+  final bool legacyFirmware;
+}
+
+class _StaleHomeStatus implements Exception {
+  const _StaleHomeStatus();
 }

--- a/chameleonultragui/lib/gui/page/slot_manager.dart
+++ b/chameleonultragui/lib/gui/page/slot_manager.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:chameleonultragui/gui/component/card_list.dart';
 import 'package:chameleonultragui/gui/component/error_page.dart';
 import 'package:chameleonultragui/gui/menu/dialogs/slot/settings.dart';
+import 'package:chameleonultragui/helpers/connected_device_session.dart';
 import 'package:chameleonultragui/helpers/definitions.dart';
 import 'package:chameleonultragui/helpers/general.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/general.dart';
@@ -16,6 +17,10 @@ import 'package:provider/provider.dart';
 
 // Localizations
 import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
+
+class _SlotUploadCanceled implements Exception {
+  const _SlotUploadCanceled();
+}
 
 class SlotManagerPage extends StatefulWidget {
   const SlotManagerPage({super.key});
@@ -52,9 +57,32 @@ class SlotManagerPageState extends State<SlotManagerPage> {
     var appState = context.read<ChameleonGUIState>();
     var localizations = AppLocalizations.of(context)!;
 
-    usedSlots = await appState.communicator!.getSlotTagTypes();
-    enabledSlots = await appState.communicator!.getEnabledSlots();
-    slotData = await appState.communicator!.getSlotTagNames();
+    final result = await appState.runSessionBoundForeground((session) async {
+      final nextUsedSlots = await session.communicator.getSlotTagTypes();
+      if (!mounted || !session.isCurrent) return null;
+      final nextEnabledSlots = await session.communicator.getEnabledSlots();
+      if (!mounted || !session.isCurrent) return null;
+      final nextSlotData = await session.communicator.getSlotTagNames();
+      if (!mounted || !session.isCurrent) return null;
+      return (
+        usedSlots: nextUsedSlots,
+        enabledSlots: nextEnabledSlots,
+        slotData: nextSlotData,
+      );
+    });
+    final session = result.session;
+    final data = result.value;
+    if (!result.executed ||
+        session == null ||
+        data == null ||
+        !mounted ||
+        !session.isCurrent) {
+      return;
+    }
+
+    usedSlots = data.usedSlots;
+    enabledSlots = data.enabledSlots;
+    slotData = data.slotData;
 
     for (SlotNames slot in slotData) {
       slot.hf = slot.hf.isEmpty ? localizations.no_name : slot.hf;
@@ -81,6 +109,44 @@ class SlotManagerPageState extends State<SlotManagerPage> {
   Future<void> onTap(
       CardSave card, dynamic close, AppLocalizations localizations) async {
     var appState = Provider.of<ChameleonGUIState>(context, listen: false);
+    final targetSlot = gridPosition;
+    await appState.runSessionBoundForeground((session) async {
+      try {
+        await _uploadCard(
+          card,
+          close,
+          localizations,
+          session,
+          targetSlot,
+        );
+      } on _SlotUploadCanceled {
+        // A reconnect invalidates the in-flight workflow.
+      } finally {
+        if (mounted && progress != -1) {
+          setUploadState(-1);
+        }
+      }
+    });
+  }
+
+  Future<void> _uploadCard(
+    CardSave card,
+    dynamic close,
+    AppLocalizations localizations,
+    ConnectedDeviceSession session,
+    int gridPosition,
+  ) async {
+    final appState = session.appState;
+    Future<T> command<T>(Future<T> Function() operation) async {
+      if (!mounted || !session.isCurrent) {
+        throw const _SlotUploadCanceled();
+      }
+      final value = await operation();
+      if (!mounted || !session.isCurrent) {
+        throw const _SlotUploadCanceled();
+      }
+      return value;
+    }
 
     if (isMifareClassic(card.tag)) {
       close(context, card.name);
@@ -90,18 +156,20 @@ class SlotManagerPageState extends State<SlotManagerPage> {
         card.tag = TagType.mifare2K;
       }
 
-      await appState.communicator!.setReaderDeviceMode(false);
-      await appState.communicator!
-          .enableSlot(gridPosition, TagFrequency.hf, true);
-      await appState.communicator!.activateSlot(gridPosition);
-      await appState.communicator!.setSlotType(gridPosition, card.tag);
-      await appState.communicator!.setDefaultDataToSlot(gridPosition, card.tag);
+      await command(() => session.communicator.setReaderDeviceMode(false));
+      await command(() =>
+          session.communicator.enableSlot(gridPosition, TagFrequency.hf, true));
+      await command(() => session.communicator.activateSlot(gridPosition));
+      await command(
+          () => session.communicator.setSlotType(gridPosition, card.tag));
+      await command(() =>
+          session.communicator.setDefaultDataToSlot(gridPosition, card.tag));
       var cardData = CardData(
           uid: hexToBytes(card.uid),
           atqa: card.atqa,
           sak: card.sak,
           ats: card.ats);
-      await appState.communicator!.setMf1AntiCollision(cardData);
+      await command(() => session.communicator.setMf1AntiCollision(cardData));
 
       List<int> blockChunk = [];
       int lastSend = 0;
@@ -115,8 +183,8 @@ class SlotManagerPageState extends State<SlotManagerPage> {
                 card.data[blockOffset].isEmpty) ||
             blockChunk.length >= 128) {
           if (blockChunk.isNotEmpty) {
-            await appState.communicator!
-                .setMf1BlockData(lastSend, Uint8List.fromList(blockChunk));
+            await command(() => session.communicator
+                .setMf1BlockData(lastSend, Uint8List.fromList(blockChunk)));
             blockChunk = [];
             lastSend = blockOffset;
           }
@@ -132,181 +200,199 @@ class SlotManagerPageState extends State<SlotManagerPage> {
                     chameleonTagTypeGetMfClassicType(card.tag)) *
                 100)
             .round());
-        await asyncSleep(1);
+        await command(() => asyncSleep(1));
       }
 
       if (blockChunk.isNotEmpty) {
-        await appState.communicator!
-            .setMf1BlockData(lastSend, Uint8List.fromList(blockChunk));
+        await command(() => session.communicator
+            .setMf1BlockData(lastSend, Uint8List.fromList(blockChunk)));
       }
 
       setUploadState(100);
 
-      await appState.communicator!.setSlotTagName(
+      await command(() => session.communicator.setSlotTagName(
           gridPosition,
           (card.name.isEmpty) ? localizations.no_name : card.name,
-          TagFrequency.hf);
-      await appState.communicator!.saveSlotData();
+          TagFrequency.hf));
+      await command(session.communicator.saveSlotData);
       appState.changesMade();
       refreshSlot();
     } else if (isEM410X(card.tag)) {
       close(context, card.name);
-      await appState.communicator!.setReaderDeviceMode(false);
-      await appState.communicator!
-          .enableSlot(gridPosition, TagFrequency.lf, true);
-      await appState.communicator!.activateSlot(gridPosition);
+      await command(() => session.communicator.setReaderDeviceMode(false));
+      await command(() =>
+          session.communicator.enableSlot(gridPosition, TagFrequency.lf, true));
+      await command(() => session.communicator.activateSlot(gridPosition));
       TagType slotTagType = card.tag == TagType.em410XElectra
           ? TagType.em410XElectra
           : TagType.em410X;
-      await appState.communicator!.setSlotType(gridPosition, slotTagType);
-      await appState.communicator!
-          .setDefaultDataToSlot(gridPosition, slotTagType);
-      await appState.communicator!.setEM410XEmulatorID(hexToBytes(card.uid));
-      await appState.communicator!.setSlotTagName(
+      await command(
+          () => session.communicator.setSlotType(gridPosition, slotTagType));
+      await command(() =>
+          session.communicator.setDefaultDataToSlot(gridPosition, slotTagType));
+      await command(
+          () => session.communicator.setEM410XEmulatorID(hexToBytes(card.uid)));
+      await command(() => session.communicator.setSlotTagName(
           gridPosition,
           (card.name.isEmpty) ? localizations.no_name : card.name,
-          TagFrequency.lf);
-      await appState.communicator!.saveSlotData();
+          TagFrequency.lf));
+      await command(session.communicator.saveSlotData);
       appState.changesMade();
       refreshSlot();
     } else if (card.tag == TagType.hidProx) {
       close(context, card.name);
-      await appState.communicator!.setReaderDeviceMode(false);
-      await appState.communicator!
-          .enableSlot(gridPosition, TagFrequency.lf, true);
-      await appState.communicator!.activateSlot(gridPosition);
-      await appState.communicator!.setSlotType(gridPosition, card.tag);
-      await appState.communicator!.setDefaultDataToSlot(gridPosition, card.tag);
-      await appState.communicator!.setHIDProxEmulatorID(
-          hexToBytes(HIDCard.fromUID(card.uid).toString()));
-      await appState.communicator!.setSlotTagName(
+      await command(() => session.communicator.setReaderDeviceMode(false));
+      await command(() =>
+          session.communicator.enableSlot(gridPosition, TagFrequency.lf, true));
+      await command(() => session.communicator.activateSlot(gridPosition));
+      await command(
+          () => session.communicator.setSlotType(gridPosition, card.tag));
+      await command(() =>
+          session.communicator.setDefaultDataToSlot(gridPosition, card.tag));
+      await command(() => session.communicator.setHIDProxEmulatorID(
+          hexToBytes(HIDCard.fromUID(card.uid).toString())));
+      await command(() => session.communicator.setSlotTagName(
           gridPosition,
           (card.name.isEmpty) ? localizations.no_name : card.name,
-          TagFrequency.lf);
-      await appState.communicator!.saveSlotData();
+          TagFrequency.lf));
+      await command(session.communicator.saveSlotData);
       appState.changesMade();
       refreshSlot();
     } else if (card.tag == TagType.viking) {
       close(context, card.name);
-      await appState.communicator!.setReaderDeviceMode(false);
-      await appState.communicator!
-          .enableSlot(gridPosition, TagFrequency.lf, true);
-      await appState.communicator!.activateSlot(gridPosition);
-      await appState.communicator!.setSlotType(gridPosition, card.tag);
-      await appState.communicator!.setDefaultDataToSlot(gridPosition, card.tag);
-      await appState.communicator!.setVikingEmulatorID(hexToBytes(card.uid));
-      await appState.communicator!.setSlotTagName(
+      await command(() => session.communicator.setReaderDeviceMode(false));
+      await command(() =>
+          session.communicator.enableSlot(gridPosition, TagFrequency.lf, true));
+      await command(() => session.communicator.activateSlot(gridPosition));
+      await command(
+          () => session.communicator.setSlotType(gridPosition, card.tag));
+      await command(() =>
+          session.communicator.setDefaultDataToSlot(gridPosition, card.tag));
+      await command(
+          () => session.communicator.setVikingEmulatorID(hexToBytes(card.uid)));
+      await command(() => session.communicator.setSlotTagName(
           gridPosition,
           (card.name.isEmpty) ? localizations.no_name : card.name,
-          TagFrequency.lf);
-      await appState.communicator!.saveSlotData();
+          TagFrequency.lf));
+      await command(session.communicator.saveSlotData);
       appState.changesMade();
       refreshSlot();
     } else if (card.tag == TagType.pac) {
       close(context, card.name);
-      await appState.communicator!.setReaderDeviceMode(false);
-      await appState.communicator!
-          .enableSlot(gridPosition, TagFrequency.lf, true);
-      await appState.communicator!.activateSlot(gridPosition);
-      await appState.communicator!.setSlotType(gridPosition, card.tag);
-      await appState.communicator!.setDefaultDataToSlot(gridPosition, card.tag);
-      await appState.communicator!.setPacEmulatorID(hexToBytes(card.uid));
-      await appState.communicator!.setSlotTagName(
+      await command(() => session.communicator.setReaderDeviceMode(false));
+      await command(() =>
+          session.communicator.enableSlot(gridPosition, TagFrequency.lf, true));
+      await command(() => session.communicator.activateSlot(gridPosition));
+      await command(
+          () => session.communicator.setSlotType(gridPosition, card.tag));
+      await command(() =>
+          session.communicator.setDefaultDataToSlot(gridPosition, card.tag));
+      await command(
+          () => session.communicator.setPacEmulatorID(hexToBytes(card.uid)));
+      await command(() => session.communicator.setSlotTagName(
           gridPosition,
           (card.name.isEmpty) ? localizations.no_name : card.name,
-          TagFrequency.lf);
-      await appState.communicator!.saveSlotData();
+          TagFrequency.lf));
+      await command(session.communicator.saveSlotData);
       appState.changesMade();
       refreshSlot();
     } else if (card.tag == TagType.ioProx) {
       close(context, card.name);
-      await appState.communicator!.setReaderDeviceMode(false);
-      await appState.communicator!
-          .enableSlot(gridPosition, TagFrequency.lf, true);
-      await appState.communicator!.activateSlot(gridPosition);
-      await appState.communicator!.setSlotType(gridPosition, card.tag);
-      await appState.communicator!.setDefaultDataToSlot(gridPosition, card.tag);
-      await appState.communicator!.setIoProxEmulatorID(hexToBytes(card.uid));
-      await appState.communicator!.setSlotTagName(
+      await command(() => session.communicator.setReaderDeviceMode(false));
+      await command(() =>
+          session.communicator.enableSlot(gridPosition, TagFrequency.lf, true));
+      await command(() => session.communicator.activateSlot(gridPosition));
+      await command(
+          () => session.communicator.setSlotType(gridPosition, card.tag));
+      await command(() =>
+          session.communicator.setDefaultDataToSlot(gridPosition, card.tag));
+      await command(
+          () => session.communicator.setIoProxEmulatorID(hexToBytes(card.uid)));
+      await command(() => session.communicator.setSlotTagName(
           gridPosition,
           (card.name.isEmpty) ? localizations.no_name : card.name,
-          TagFrequency.lf);
-      await appState.communicator!.saveSlotData();
+          TagFrequency.lf));
+      await command(session.communicator.saveSlotData);
       appState.changesMade();
       refreshSlot();
     } else if (card.tag == TagType.idteck) {
       close(context, card.name);
-      await appState.communicator!.setReaderDeviceMode(false);
-      await appState.communicator!
-          .enableSlot(gridPosition, TagFrequency.lf, true);
-      await appState.communicator!.activateSlot(gridPosition);
-      await appState.communicator!.setSlotType(gridPosition, card.tag);
-      await appState.communicator!.setDefaultDataToSlot(gridPosition, card.tag);
-      await appState.communicator!.setIdteckEmulatorID(hexToBytes(card.uid));
-      await appState.communicator!.setSlotTagName(
+      await command(() => session.communicator.setReaderDeviceMode(false));
+      await command(() =>
+          session.communicator.enableSlot(gridPosition, TagFrequency.lf, true));
+      await command(() => session.communicator.activateSlot(gridPosition));
+      await command(
+          () => session.communicator.setSlotType(gridPosition, card.tag));
+      await command(() =>
+          session.communicator.setDefaultDataToSlot(gridPosition, card.tag));
+      await command(
+          () => session.communicator.setIdteckEmulatorID(hexToBytes(card.uid)));
+      await command(() => session.communicator.setSlotTagName(
           gridPosition,
           (card.name.isEmpty) ? localizations.no_name : card.name,
-          TagFrequency.lf);
-      await appState.communicator!.saveSlotData();
+          TagFrequency.lf));
+      await command(session.communicator.saveSlotData);
       appState.changesMade();
       refreshSlot();
     } else if (isMifareUltralight(card.tag)) {
       close(context, card.name);
       setUploadState(0);
 
-      await appState.communicator!.setReaderDeviceMode(false);
-      await appState.communicator!
-          .enableSlot(gridPosition, TagFrequency.hf, true);
-      await appState.communicator!.activateSlot(gridPosition);
-      await appState.communicator!.setSlotType(gridPosition, card.tag);
-      await appState.communicator!.setDefaultDataToSlot(gridPosition, card.tag);
+      await command(() => session.communicator.setReaderDeviceMode(false));
+      await command(() =>
+          session.communicator.enableSlot(gridPosition, TagFrequency.hf, true));
+      await command(() => session.communicator.activateSlot(gridPosition));
+      await command(
+          () => session.communicator.setSlotType(gridPosition, card.tag));
+      await command(() =>
+          session.communicator.setDefaultDataToSlot(gridPosition, card.tag));
       var cardData = CardData(
           uid: hexToBytes(card.uid),
           atqa: card.atqa,
           sak: card.sak,
           ats: card.ats);
-      await appState.communicator!.setMf1AntiCollision(cardData);
+      await command(() => session.communicator.setMf1AntiCollision(cardData));
 
       for (var page = 0;
           page < mfUltralightGetPagesCount(card.tag) && card.data.length > page;
           page++) {
-        await appState.communicator!
-            .mf0EmulatorWritePages(page, card.data[page]);
+        await command(() =>
+            session.communicator.mf0EmulatorWritePages(page, card.data[page]));
 
         setUploadState(
             (page / mfUltralightGetPagesCount(card.tag) * 100).round());
 
-        await asyncSleep(1);
+        await command(() => asyncSleep(1));
       }
 
       if (card.extraData.ultralightVersion.isNotEmpty) {
-        await appState.communicator!
-            .mf0EmulatorSetVersionData(card.extraData.ultralightVersion);
+        await command(() => session.communicator
+            .mf0EmulatorSetVersionData(card.extraData.ultralightVersion));
       }
 
       if (card.extraData.ultralightSignature.isNotEmpty) {
-        await appState.communicator!
-            .mf0EmulatorSetSignatureData(card.extraData.ultralightSignature);
+        await command(() => session.communicator
+            .mf0EmulatorSetSignatureData(card.extraData.ultralightSignature));
       }
 
       if (card.extraData.ultralightCounters.isNotEmpty) {
         for (int i = 0; i < card.extraData.ultralightCounters.length; i++) {
-          await appState.communicator!.mf0EmulatorSetCounterData(
-              i, card.extraData.ultralightCounters[i], true);
+          await command(() => session.communicator.mf0EmulatorSetCounterData(
+              i, card.extraData.ultralightCounters[i], true));
         }
       }
 
       if (mfUltralightHasCounters(card.tag)) {
-        await appState.communicator!.mf0ResetAuthCount();
+        await command(session.communicator.mf0ResetAuthCount);
       }
 
       setUploadState(100);
 
-      await appState.communicator!.setSlotTagName(
+      await command(() => session.communicator.setSlotTagName(
           gridPosition,
           (card.name.isEmpty) ? localizations.no_name : card.name,
-          TagFrequency.hf);
-      await appState.communicator!.saveSlotData();
+          TagFrequency.hf));
+      await command(session.communicator.saveSlotData);
       appState.changesMade();
       refreshSlot();
     } else {

--- a/chameleonultragui/lib/gui/page/write_card.dart
+++ b/chameleonultragui/lib/gui/page/write_card.dart
@@ -1,5 +1,6 @@
 import 'package:chameleonultragui/connector/serial_abstract.dart';
 import 'package:chameleonultragui/gui/component/card_list.dart';
+import 'package:chameleonultragui/helpers/connected_device_session.dart';
 import 'package:chameleonultragui/helpers/definitions.dart';
 import 'package:chameleonultragui/helpers/general.dart';
 import 'package:chameleonultragui/helpers/write.dart';
@@ -41,18 +42,22 @@ class WriteCardPageState extends State<WriteCardPage> {
   Future<void> onTap(CardSave selectedCard, dynamic close,
       AppLocalizations localizations) async {
     var appState = Provider.of<ChameleonGUIState>(context, listen: false);
+    final communicator = appState.communicator;
+    if (communicator == null) return;
+    final selectedBaseHelper = AbstractWriteHelper.getClassByCardType(
+      selectedCard.tag,
+      appState,
+      updateState,
+      localizations,
+      operationCanContinue: () =>
+          appState.hasConnectedCommunicator(communicator),
+    );
 
     setState(() {
       card = selectedCard;
-      baseHelper = AbstractWriteHelper.getClassByCardType(
-          selectedCard.tag, appState, updateState, localizations);
+      baseHelper = selectedBaseHelper;
+      helper = selectedBaseHelper?.getAvailableMethods()[0];
     });
-
-    if (baseHelper != null) {
-      setState(() {
-        helper = baseHelper!.getAvailableMethods()[0];
-      });
-    }
 
     await helper?.getCardType();
 
@@ -126,12 +131,40 @@ class WriteCardPageState extends State<WriteCardPage> {
     var localizations = AppLocalizations.of(context)!;
     SnackBar snackBar;
     updateProgress(0);
+    final selectedHelper = helper;
+    final selectedCard = card;
 
-    if (!await appState.communicator!.isReaderDeviceMode()) {
-      await appState.communicator!.setReaderDeviceMode(true);
+    final result = await appState.runSessionBoundForegroundCatching<bool>(
+      (session) async {
+        if (selectedHelper == null ||
+            selectedCard == null ||
+            !identical(selectedHelper.communicator, session.communicator)) {
+          return false;
+        }
+        selectedHelper.setOperationContinuation(
+          () => mounted && session.isCurrent,
+        );
+        if (!selectedHelper.operationCanContinue) return false;
+
+        if (!await session.communicator.isReaderDeviceMode()) {
+          if (!selectedHelper.operationCanContinue) return false;
+          await session.communicator.setReaderDeviceMode(true);
+        }
+        if (!selectedHelper.operationCanContinue) return false;
+
+        return selectedHelper.writeData(selectedCard, (writeProgress) {
+          if (selectedHelper.operationCanContinue) {
+            updateProgress(writeProgress);
+          }
+        });
+      },
+    );
+    if (result.error != null) {
+      appState.log?.e('Failed to write card: ${result.error}');
     }
+    if (!mounted) return;
 
-    if (await helper!.writeData(card!, updateProgress)) {
+    if (result.executed && result.error == null && result.value == true) {
       snackBar = SnackBar(
         content: Text(localizations.magic_success_write),
         action: SnackBarAction(

--- a/chameleonultragui/lib/gui/page/write_card.dart
+++ b/chameleonultragui/lib/gui/page/write_card.dart
@@ -27,6 +27,26 @@ class WriteCardPageState extends State<WriteCardPage> {
   AbstractWriteHelper? baseHelper;
   AbstractWriteHelper? helper;
 
+  Future<SessionBoundRfResult<T?>> _runHelperPreflight<T>(
+    ChameleonGUIState appState,
+    AbstractWriteHelper selectedHelper,
+    Future<T> Function(AbstractWriteHelper helper) operation,
+  ) {
+    return appState.runSessionBoundForegroundCatching<T?>((session) async {
+      if (!mounted ||
+          !identical(selectedHelper.communicator, session.communicator)) {
+        return null;
+      }
+      selectedHelper.setOperationContinuation(
+        () => mounted && session.isCurrent,
+      );
+      if (!selectedHelper.operationCanContinue) return null;
+
+      final value = await operation(selectedHelper);
+      return selectedHelper.operationCanContinue ? value : null;
+    });
+  }
+
   Future<String?> cardSelectDialog(BuildContext context) {
     var appState = context.read<ChameleonGUIState>();
     var tags = appState.sharedPreferencesProvider.getCards();
@@ -53,13 +73,32 @@ class WriteCardPageState extends State<WriteCardPage> {
           appState.hasConnectedCommunicator(communicator),
     );
 
+    final selectedHelper = selectedBaseHelper?.getAvailableMethods()[0];
     setState(() {
       card = selectedCard;
       baseHelper = selectedBaseHelper;
-      helper = selectedBaseHelper?.getAvailableMethods()[0];
+      helper = selectedHelper;
     });
 
-    await helper?.getCardType();
+    if (selectedHelper != null) {
+      final result = await _runHelperPreflight<bool>(
+        appState,
+        selectedHelper,
+        (helper) async {
+          await helper.getCardType();
+          return true;
+        },
+      );
+      if (result.error != null) {
+        appState.log?.e('Failed to probe selected card: ${result.error}');
+      }
+      if (!mounted ||
+          result.value != true ||
+          !identical(card, selectedCard) ||
+          !identical(helper, selectedHelper)) {
+        return;
+      }
+    }
 
     if (!mounted) return;
     close(context, selectedCard.name);
@@ -67,50 +106,101 @@ class WriteCardPageState extends State<WriteCardPage> {
 
   Future<void> detectMagicType() async {
     var appState = Provider.of<ChameleonGUIState>(context, listen: false);
-    var scaffoldMessenger = ScaffoldMessenger.of(context);
-    var localizations = AppLocalizations.of(context)!;
+    final selectedBaseHelper = baseHelper;
+    final selectedCard = card;
+    if (selectedBaseHelper == null || selectedCard == null) return;
+    final availableMethods = selectedBaseHelper.getAvailableMethods();
 
-    if (!await appState.communicator!.isReaderDeviceMode()) {
-      await appState.communicator!.setReaderDeviceMode(true);
-    }
+    final result = await appState.runSessionBoundForegroundCatching<
+        ({bool completed, AbstractWriteHelper? helper})>((session) async {
+      bool canContinue() => mounted && session.isCurrent;
+      if (!canContinue() ||
+          !identical(selectedBaseHelper.communicator, session.communicator)) {
+        return (completed: false, helper: null);
+      }
 
-    for (final magicHelper in baseHelper!.getAvailableMethods()) {
-      if (await magicHelper.isMagic(card)) {
-        setState(() {
-          helper = magicHelper;
-        });
+      if (!await session.communicator.isReaderDeviceMode()) {
+        if (!canContinue()) return (completed: false, helper: null);
+        await session.communicator.setReaderDeviceMode(true);
+      }
+      if (!canContinue()) return (completed: false, helper: null);
 
-        try {
-          await helper?.getCardType();
-        } catch (_) {
-          await helper?.getCardType();
+      for (final magicHelper in availableMethods) {
+        if (!identical(magicHelper.communicator, session.communicator)) {
+          return (completed: false, helper: null);
+        }
+        magicHelper.setOperationContinuation(canContinue);
+        if (!magicHelper.operationCanContinue) {
+          return (completed: false, helper: null);
+        }
+        if (!await magicHelper.isMagic(selectedCard)) {
+          if (!magicHelper.operationCanContinue) {
+            return (completed: false, helper: null);
+          }
+          continue;
+        }
+        if (!magicHelper.operationCanContinue) {
+          return (completed: false, helper: null);
         }
 
-        appState.log!.i("Detected Magic card type: ${magicHelper.name}");
-        scaffoldMessenger.hideCurrentSnackBar();
-        var snackBar = SnackBar(
+        try {
+          await magicHelper.getCardType();
+        } catch (_) {
+          if (!magicHelper.operationCanContinue) {
+            return (completed: false, helper: null);
+          }
+          await magicHelper.getCardType();
+        }
+        if (!magicHelper.operationCanContinue) {
+          return (completed: false, helper: null);
+        }
+        return (completed: true, helper: magicHelper);
+      }
+
+      return (completed: true, helper: null);
+    });
+    if (result.error != null) {
+      appState.log?.e('Failed to detect Magic card type: ${result.error}');
+    }
+    if (!mounted ||
+        result.error != null ||
+        result.value?.completed != true ||
+        !identical(baseHelper, selectedBaseHelper) ||
+        !identical(card, selectedCard)) {
+      return;
+    }
+
+    final scaffoldMessenger = ScaffoldMessenger.of(context);
+    final localizations = AppLocalizations.of(context)!;
+    final detectedHelper = result.value!.helper;
+    if (detectedHelper != null) {
+      setState(() {
+        helper = detectedHelper;
+      });
+      appState.log?.i("Detected Magic card type: ${detectedHelper.name}");
+      scaffoldMessenger.hideCurrentSnackBar();
+      scaffoldMessenger.showSnackBar(
+        SnackBar(
           content: Text(
-              '${localizations.detected_magic_card_type}: ${helper!.name}'),
+              '${localizations.detected_magic_card_type}: ${detectedHelper.name}'),
           action: SnackBarAction(
             label: localizations.close,
             onPressed: () {},
           ),
-        );
-
-        scaffoldMessenger.showSnackBar(snackBar);
-        return;
-      }
+        ),
+      );
+      return;
     }
 
-    var snackBar = SnackBar(
-      content: Text(localizations.failed_to_detect_magic_card_type),
-      action: SnackBarAction(
-        label: localizations.close,
-        onPressed: () {},
+    scaffoldMessenger.showSnackBar(
+      SnackBar(
+        content: Text(localizations.failed_to_detect_magic_card_type),
+        action: SnackBarAction(
+          label: localizations.close,
+          onPressed: () {},
+        ),
       ),
     );
-
-    scaffoldMessenger.showSnackBar(snackBar);
   }
 
   void updateState() {
@@ -226,8 +316,26 @@ class WriteCardPageState extends State<WriteCardPage> {
     } else if (helper != null && helper!.isReady() && progress == -1) {
       SnackBar snackBar;
       updateProgress(0);
+      final selectedHelper = helper!;
+      final selectedCard = card!;
+      final result = await _runHelperPreflight<bool>(
+        appState,
+        selectedHelper,
+        (helper) => helper.isCompatible(selectedCard),
+      );
+      if (result.error != null) {
+        appState.log?.e('Failed to check card compatibility: ${result.error}');
+      }
+      if (!mounted ||
+          result.error != null ||
+          result.value == null ||
+          !identical(helper, selectedHelper) ||
+          !identical(card, selectedCard)) {
+        if (mounted) updateProgress(-1);
+        return;
+      }
 
-      if (!await helper!.isCompatible(card!)) {
+      if (!result.value!) {
         snackBar = SnackBar(
           content: Text(localizations.magic_incompatible_card),
           action: SnackBarAction(

--- a/chameleonultragui/lib/helpers/connected_device_session.dart
+++ b/chameleonultragui/lib/helpers/connected_device_session.dart
@@ -1,0 +1,123 @@
+import 'package:chameleonultragui/bridge/chameleon.dart';
+import 'package:chameleonultragui/connector/serial_abstract.dart';
+import 'package:chameleonultragui/main.dart';
+
+class ConnectedDeviceSession {
+  final ChameleonGUIState appState;
+  final AbstractSerial connector;
+  final ChameleonCommunicator communicator;
+
+  const ConnectedDeviceSession._({
+    required this.appState,
+    required this.connector,
+    required this.communicator,
+  });
+
+  static ConnectedDeviceSession? capture(ChameleonGUIState appState) {
+    final connector = appState.connector;
+    final communicator = appState.communicator;
+    if (connector == null ||
+        communicator == null ||
+        !connector.connected ||
+        connector.isDFU) {
+      return null;
+    }
+    return ConnectedDeviceSession._(
+      appState: appState,
+      connector: connector,
+      communicator: communicator,
+    );
+  }
+
+  bool get isCurrent =>
+      identical(appState.connector, connector) &&
+      appState.hasConnectedCommunicator(communicator);
+}
+
+/// The observable outcome of a session-bound foreground RF operation.
+///
+/// [executed] distinguishes a rejected operation from a callback that
+/// successfully returned `null`.
+class SessionBoundRfResult<T> {
+  const SessionBoundRfResult.rejected()
+      : executed = false,
+        session = null,
+        value = null,
+        error = null,
+        stackTrace = null;
+
+  const SessionBoundRfResult.completed({
+    required ConnectedDeviceSession this.session,
+    required this.value,
+  })  : executed = true,
+        error = null,
+        stackTrace = null;
+
+  const SessionBoundRfResult.failed({
+    required ConnectedDeviceSession this.session,
+    required Object this.error,
+    required StackTrace this.stackTrace,
+  })  : executed = true,
+        value = null;
+
+  final bool executed;
+  final ConnectedDeviceSession? session;
+  final T? value;
+  final Object? error;
+  final StackTrace? stackTrace;
+}
+
+extension SessionBoundRfOperations on ChameleonGUIState {
+  /// Runs [operation] with exclusive foreground RF access for this connection.
+  ///
+  /// The session is captured before enqueueing and checked again when its FIFO
+  /// lease is acquired. Multi-command callbacks should check [session.isCurrent]
+  /// before issuing follow-up commands.
+  Future<SessionBoundRfResult<T>> runSessionBoundForeground<T>(
+    Future<T> Function(ConnectedDeviceSession session) operation,
+  ) {
+    final session = ConnectedDeviceSession.capture(this);
+    if (session == null) {
+      return Future.value(const SessionBoundRfResult.rejected());
+    }
+
+    return rfOperations.runForeground(() async {
+      if (!session.isCurrent) {
+        return const SessionBoundRfResult.rejected();
+      }
+
+      return SessionBoundRfResult.completed(
+        session: session,
+        value: await operation(session),
+      );
+    });
+  }
+
+  /// Like [runSessionBoundForeground], but reports callback failures as data.
+  Future<SessionBoundRfResult<T>> runSessionBoundForegroundCatching<T>(
+    Future<T> Function(ConnectedDeviceSession session) operation,
+  ) async {
+    final outerResult =
+        await runSessionBoundForeground<SessionBoundRfResult<T>>(
+      (session) async {
+        try {
+          return SessionBoundRfResult.completed(
+            session: session,
+            value: await operation(session),
+          );
+        } catch (error, stackTrace) {
+          return SessionBoundRfResult.failed(
+            session: session,
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }
+      },
+    );
+
+    if (!outerResult.executed) {
+      return const SessionBoundRfResult.rejected();
+    }
+    return outerResult.value!;
+  }
+}

--- a/chameleonultragui/lib/helpers/mifare_classic/general.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/general.dart
@@ -101,30 +101,43 @@ final gMifareClassicBackdoorKeys = gMifareClassicBackdoorKeysList
         ]))
     .toList();
 
-Future<MifareClassicType> mfClassicGetType(
-    ChameleonCommunicator communicator) async {
+Future<MifareClassicType> mfClassicGetType(ChameleonCommunicator communicator,
+    {bool Function()? canContinue}) async {
+  bool operationCanContinue() => canContinue?.call() ?? true;
+
+  if (!operationCanContinue()) return MifareClassicType.none;
   if ((await communicator.send14ARaw(Uint8List.fromList([0x60, 255]),
               checkResponseCrc: false))
           .length ==
       4) {
-    return MifareClassicType.m4k;
+    return operationCanContinue()
+        ? MifareClassicType.m4k
+        : MifareClassicType.none;
   }
 
+  if (!operationCanContinue()) return MifareClassicType.none;
   if ((await communicator.send14ARaw(Uint8List.fromList([0x60, 80]),
               checkResponseCrc: false))
           .length ==
       4) {
-    return MifareClassicType.m2k;
+    return operationCanContinue()
+        ? MifareClassicType.m2k
+        : MifareClassicType.none;
   }
 
+  if (!operationCanContinue()) return MifareClassicType.none;
   if ((await communicator.send14ARaw(Uint8List.fromList([0x60, 63]),
               checkResponseCrc: false))
           .length ==
       4) {
-    return MifareClassicType.m1k;
+    return operationCanContinue()
+        ? MifareClassicType.m1k
+        : MifareClassicType.none;
   }
 
-  return MifareClassicType.mini;
+  return operationCanContinue()
+      ? MifareClassicType.mini
+      : MifareClassicType.none;
 }
 
 Future<bool> mfClassicHasBackdoor(ChameleonCommunicator communicator) async {

--- a/chameleonultragui/lib/helpers/mifare_classic/write/base.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/write/base.dart
@@ -29,24 +29,31 @@ class BaseMifareClassicWriteHelper extends AbstractWriteHelper {
 
   BaseMifareClassicWriteHelper(super.communicator,
       {required this.recovery,
+      required super.operationCanContinue,
       this.type = MifareClassicType.m1k,
       this.isEV1 = false});
 
   @override
   List<AbstractWriteHelper> getAvailableMethods() {
     return [
-      MifareClassicGen1WriteHelper(communicator, recovery: recovery),
-      MifareClassicGen2WriteHelper(communicator, recovery: recovery),
-      MifareClassicGen3WriteHelper(communicator, recovery: recovery)
+      MifareClassicGen1WriteHelper(communicator,
+          recovery: recovery, operationCanContinue: () => operationCanContinue),
+      MifareClassicGen2WriteHelper(communicator,
+          recovery: recovery, operationCanContinue: () => operationCanContinue),
+      MifareClassicGen3WriteHelper(communicator,
+          recovery: recovery, operationCanContinue: () => operationCanContinue)
     ];
   }
 
   @override
   List<AbstractWriteHelper> getAvailableMethodsByPriority() {
     return [
-      MifareClassicGen1WriteHelper(communicator, recovery: recovery),
-      MifareClassicGen3WriteHelper(communicator, recovery: recovery),
-      MifareClassicGen2WriteHelper(communicator, recovery: recovery)
+      MifareClassicGen1WriteHelper(communicator,
+          recovery: recovery, operationCanContinue: () => operationCanContinue),
+      MifareClassicGen3WriteHelper(communicator,
+          recovery: recovery, operationCanContinue: () => operationCanContinue),
+      MifareClassicGen2WriteHelper(communicator,
+          recovery: recovery, operationCanContinue: () => operationCanContinue)
     ];
   }
 

--- a/chameleonultragui/lib/helpers/mifare_classic/write/base.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/write/base.dart
@@ -64,15 +64,25 @@ class BaseMifareClassicWriteHelper extends AbstractWriteHelper {
 
   @override
   Future<void> getCardType() async {
-    if (!await communicator.isReaderDeviceMode()) {
+    if (!operationCanContinue) return;
+    final isReaderMode = await communicator.isReaderDeviceMode();
+    if (!operationCanContinue) return;
+    if (!isReaderMode) {
       await communicator.setReaderDeviceMode(true);
+      if (!operationCanContinue) return;
     }
 
-    var mifare = await communicator.detectMf1Support();
     type = MifareClassicType.none;
+    final mifare = await communicator.detectMf1Support();
+    if (!operationCanContinue) return;
 
     if (mifare) {
-      type = await mfClassicGetType(communicator);
+      final detectedType = await mfClassicGetType(
+        communicator,
+        canContinue: () => operationCanContinue,
+      );
+      if (!operationCanContinue) return;
+      type = detectedType;
     }
   }
 
@@ -155,9 +165,10 @@ class BaseMifareClassicWriteHelper extends AbstractWriteHelper {
 
   @override
   Future<bool> isCompatible(CardSave card) async {
+    if (!operationCanContinue) return false;
     CardData? magicCard = await communicator.scan14443aTag();
 
-    if (magicCard == null) {
+    if (!operationCanContinue || magicCard == null) {
       return false;
     }
 
@@ -173,7 +184,7 @@ class BaseMifareClassicWriteHelper extends AbstractWriteHelper {
         Uint8List.fromList([0x60, blockCount]),
         checkResponseCrc: false);
 
-    if (data.length != 4) {
+    if (!operationCanContinue || data.length != 4) {
       return false;
     }
 

--- a/chameleonultragui/lib/helpers/mifare_classic/write/gen1.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/write/gen1.dart
@@ -13,7 +13,9 @@ class MifareClassicGen1WriteHelper extends BaseMifareClassicWriteHelper {
   @override
   Future<bool> isMagic(dynamic data) async {
     try {
+      if (!operationCanContinue) return false;
       await communicator.send14ARaw(Uint8List(1)); // reset
+      if (!operationCanContinue) return false;
 
       Uint8List data = await communicator.send14ARaw(Uint8List.fromList([0x40]),
           bitLen: 7,
@@ -21,11 +23,12 @@ class MifareClassicGen1WriteHelper extends BaseMifareClassicWriteHelper {
           autoSelect: false,
           checkResponseCrc: false,
           keepRfField: true);
+      if (!operationCanContinue) return false;
 
       if (data.isNotEmpty && data[0] == 0x0a) {
         data = await communicator.send14ARaw(Uint8List.fromList([0x43]),
             appendCrc: false, autoSelect: false, checkResponseCrc: false);
-        return data.isNotEmpty && data[0] == 0x0a;
+        return operationCanContinue && data.isNotEmpty && data[0] == 0x0a;
       }
 
       return false;
@@ -42,8 +45,11 @@ class MifareClassicGen1WriteHelper extends BaseMifareClassicWriteHelper {
   @override
   Future<bool> writeBlock(int block, Uint8List data) async {
     for (int retry = 0; retry < 5; retry++) {
+      if (!operationCanContinue) return false;
+      var writeIssued = false;
       try {
         await communicator.send14ARaw(Uint8List(1)); // reset
+        if (!operationCanContinue) return false;
 
         await communicator.send14ARaw(Uint8List.fromList([0x40]),
             bitLen: 7,
@@ -51,24 +57,34 @@ class MifareClassicGen1WriteHelper extends BaseMifareClassicWriteHelper {
             autoSelect: false,
             checkResponseCrc: false,
             keepRfField: true);
+        if (!operationCanContinue) return false;
 
         await communicator.send14ARaw(Uint8List.fromList([0x43]),
             appendCrc: false,
             autoSelect: false,
             checkResponseCrc: false,
             keepRfField: true);
+        if (!operationCanContinue) return false;
 
         await communicator.send14ARaw(Uint8List.fromList([0xA0, block]),
             autoSelect: false, keepRfField: true, checkResponseCrc: false);
+        if (!operationCanContinue) return false;
 
+        writeIssued = true;
         Uint8List output = await communicator.send14ARaw(data,
             autoSelect: false, keepRfField: true, checkResponseCrc: false);
+        writeIssued = false;
 
-        if (output.isNotEmpty && output[0] == 0x0a) {
+        if (!operationCanContinue) return false;
+        if (output.isEmpty) return false;
+        if (output[0] == 0x0a) {
           return true;
         }
         await Future.delayed(const Duration(milliseconds: 100));
-      } catch (_) {}
+        if (!operationCanContinue) return false;
+      } catch (_) {
+        if (writeIssued) return false;
+      }
     }
 
     return false;

--- a/chameleonultragui/lib/helpers/mifare_classic/write/gen1.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/write/gen1.dart
@@ -3,7 +3,8 @@ import 'dart:typed_data';
 import 'package:chameleonultragui/helpers/mifare_classic/write/base.dart';
 
 class MifareClassicGen1WriteHelper extends BaseMifareClassicWriteHelper {
-  MifareClassicGen1WriteHelper(super.communicator, {required super.recovery});
+  MifareClassicGen1WriteHelper(super.communicator,
+      {required super.recovery, required super.operationCanContinue});
 
   @override
   String get name => "gen1";

--- a/chameleonultragui/lib/helpers/mifare_classic/write/gen2.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/write/gen2.dart
@@ -95,7 +95,7 @@ class MifareClassicGen2WriteHelper extends BaseMifareClassicWriteHelper {
           case MifareClassicMagicWriteOutcome.success:
             return operationCanContinue
                 ? outcome
-                : MifareClassicMagicWriteOutcome.rejected;
+                : MifareClassicMagicWriteOutcome.ambiguous;
           case MifareClassicMagicWriteOutcome.ambiguous:
             return outcome;
           case MifareClassicMagicWriteOutcome.rejected:

--- a/chameleonultragui/lib/helpers/mifare_classic/write/gen2.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/write/gen2.dart
@@ -19,7 +19,8 @@ enum MifareClassicMagicWriteOutcome {
 class MifareClassicGen2WriteHelper extends BaseMifareClassicWriteHelper {
   List<int> failedBlocks = [];
 
-  MifareClassicGen2WriteHelper(super.communicator, {required super.recovery});
+  MifareClassicGen2WriteHelper(super.communicator,
+      {required super.recovery, required super.operationCanContinue});
 
   @override
   String get name => "gen2";
@@ -206,7 +207,7 @@ class MifareClassicGen2WriteHelper extends BaseMifareClassicWriteHelper {
         data,
       );
       if (!operationCanContinue) {
-        return MifareClassicMagicWriteOutcome.rejected;
+        return MifareClassicMagicWriteOutcome.ambiguous;
       }
       return result
           ? MifareClassicMagicWriteOutcome.success

--- a/chameleonultragui/lib/helpers/mifare_classic/write/gen2.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/write/gen2.dart
@@ -6,9 +6,19 @@ import 'package:chameleonultragui/helpers/mifare_classic/general.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/recovery.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/write/base.dart';
 import 'package:chameleonultragui/sharedprefsprovider.dart';
+import 'package:flutter/foundation.dart' show protected;
+
+enum MifareClassicMagicWriteOutcome {
+  success,
+  rejected,
+  ambiguous;
+
+  bool get succeeded => this == MifareClassicMagicWriteOutcome.success;
+}
 
 class MifareClassicGen2WriteHelper extends BaseMifareClassicWriteHelper {
   List<int> failedBlocks = [];
+
   MifareClassicGen2WriteHelper(super.communicator, {required super.recovery});
 
   @override
@@ -18,9 +28,10 @@ class MifareClassicGen2WriteHelper extends BaseMifareClassicWriteHelper {
 
   @override
   Future<bool> isMagic(dynamic data) async {
+    if (!operationCanContinue) return false;
     CardSave cardSave = data;
     CardData? card = await communicator.scan14443aTag();
-    if (card == null) {
+    if (card == null || !operationCanContinue) {
       return false;
     }
 
@@ -48,67 +59,167 @@ class MifareClassicGen2WriteHelper extends BaseMifareClassicWriteHelper {
   }
 
   Future<bool> writeBlockModifier(CardSave card, int block, Uint8List data,
+          {bool tryBothKeys = false, bool useGenericKey = false}) async =>
+      (await writeBlockModifierOutcome(
+        card,
+        block,
+        data,
+        tryBothKeys: tryBothKeys,
+        useGenericKey: useGenericKey,
+      ))
+          .succeeded;
+
+  @protected
+  Future<MifareClassicMagicWriteOutcome> writeBlockModifierOutcome(
+      CardSave card, int block, Uint8List data,
       {bool tryBothKeys = false, bool useGenericKey = false}) async {
     for (int retry = 0; retry < 10; retry++) {
+      if (!operationCanContinue) {
+        return MifareClassicMagicWriteOutcome.rejected;
+      }
       try {
         await Future.delayed(
             const Duration(milliseconds: 50)); // Stability delay
-        if (await writeBlock(block, data,
-            tryBothKeys: tryBothKeys, useGenericKey: useGenericKey)) {
-          return true;
+        if (!operationCanContinue) {
+          return MifareClassicMagicWriteOutcome.rejected;
+        }
+        final outcome = await writeSingleBlockOutcome(
+          card,
+          block,
+          data,
+          tryBothKeys: tryBothKeys,
+          useGenericKey: useGenericKey,
+        );
+        switch (outcome) {
+          case MifareClassicMagicWriteOutcome.success:
+            return operationCanContinue
+                ? outcome
+                : MifareClassicMagicWriteOutcome.rejected;
+          case MifareClassicMagicWriteOutcome.ambiguous:
+            return outcome;
+          case MifareClassicMagicWriteOutcome.rejected:
+            break;
+        }
+        if (!operationCanContinue) {
+          return MifareClassicMagicWriteOutcome.rejected;
         }
         await Future.delayed(const Duration(milliseconds: 150));
-      } catch (_) {}
+        if (!operationCanContinue) {
+          return MifareClassicMagicWriteOutcome.rejected;
+        }
+      } catch (_) {
+        // Only failures before the typed write boundary remain retryable.
+      }
     }
 
-    return false;
+    return MifareClassicMagicWriteOutcome.rejected;
+  }
+
+  @protected
+  Future<MifareClassicMagicWriteOutcome> writeSingleBlockOutcome(
+      CardSave card, int block, Uint8List data,
+      {bool tryBothKeys = false, bool useGenericKey = false}) {
+    return writeBlockOutcome(
+      block,
+      data,
+      tryBothKeys: tryBothKeys,
+      useGenericKey: useGenericKey,
+    );
   }
 
   @override
   Future<bool> writeBlock(int block, Uint8List data,
-      {bool tryBothKeys = false, bool useGenericKey = false}) async {
-    if (await communicator.mf1WriteBlock(
+          {bool tryBothKeys = false, bool useGenericKey = false}) async =>
+      (await writeBlockOutcome(
         block,
+        data,
+        tryBothKeys: tryBothKeys,
+        useGenericKey: useGenericKey,
+      ))
+          .succeeded &&
+      operationCanContinue;
+
+  @protected
+  Future<MifareClassicMagicWriteOutcome> writeBlockOutcome(
+      int block, Uint8List data,
+      {bool tryBothKeys = false, bool useGenericKey = false}) async {
+    if (!operationCanContinue) {
+      return MifareClassicMagicWriteOutcome.rejected;
+    }
+    final sector = mfClassicGetSectorByBlock(block);
+    final keys = <(int, Uint8List)>[
+      (
         0x60,
-        (useGenericKey)
-            ? gMifareClassicKeys[0]
-            : recovery.validKeys[mfClassicGetSectorByBlock(block)],
-        data)) {
-      return true;
-    }
-
+        useGenericKey ? gMifareClassicKeys[0] : recovery.validKeys[sector],
+      ),
+    ];
     if (useGenericKey) {
-      if (await communicator.mf1WriteBlock(block, 0x60,
-          recovery.validKeys[mfClassicGetSectorByBlock(block)], data)) {
-        return true;
-      }
+      keys.add((0x60, recovery.validKeys[sector]));
     }
-
     if (tryBothKeys) {
-      if (await communicator.mf1WriteBlock(
-          block,
-          0x61,
-          (useGenericKey)
-              ? gMifareClassicKeys[0]
-              : recovery.validKeys[40 + mfClassicGetSectorByBlock(block)],
-          data)) {
-        return true;
-      }
-
+      keys.add((
+        0x61,
+        useGenericKey ? gMifareClassicKeys[0] : recovery.validKeys[40 + sector],
+      ));
       if (useGenericKey) {
-        if (await communicator.mf1WriteBlock(block, 0x61,
-            recovery.validKeys[40 + mfClassicGetSectorByBlock(block)], data)) {
-          return true;
-        }
+        keys.add((0x61, recovery.validKeys[40 + sector]));
       }
     }
 
-    return false;
+    for (final (keyType, key) in keys) {
+      if (!operationCanContinue) {
+        return MifareClassicMagicWriteOutcome.rejected;
+      }
+      final outcome = await writeAuthenticatedBlock(
+        block,
+        keyType,
+        key,
+        data,
+      );
+      switch (outcome) {
+        case MifareClassicMagicWriteOutcome.success:
+        case MifareClassicMagicWriteOutcome.ambiguous:
+          return outcome;
+        case MifareClassicMagicWriteOutcome.rejected:
+          break;
+      }
+      if (!operationCanContinue) {
+        return MifareClassicMagicWriteOutcome.rejected;
+      }
+    }
+
+    return MifareClassicMagicWriteOutcome.rejected;
+  }
+
+  @protected
+  Future<MifareClassicMagicWriteOutcome> writeAuthenticatedBlock(
+    int block,
+    int keyType,
+    Uint8List key,
+    Uint8List data,
+  ) async {
+    try {
+      final result = await communicator.mf1WriteBlock(
+        block,
+        keyType,
+        key,
+        data,
+      );
+      if (!operationCanContinue) {
+        return MifareClassicMagicWriteOutcome.rejected;
+      }
+      return result
+          ? MifareClassicMagicWriteOutcome.success
+          : MifareClassicMagicWriteOutcome.rejected;
+    } catch (_) {
+      return MifareClassicMagicWriteOutcome.ambiguous;
+    }
   }
 
   @override
   Future<bool> writeData(
       CardSave card, Function(int writeProgress) update) async {
+    if (!operationCanContinue) return false;
     List<Uint8List> data = card.data;
     List<bool> cleanSectors = List.generate(40, (index) => false);
     failedBlocks = [];
@@ -118,6 +229,7 @@ class MifareClassicGen2WriteHelper extends BaseMifareClassicWriteHelper {
     } catch (e) {
       return false;
     }
+    if (!operationCanContinue) return false;
 
     if (data.isEmpty || data[0].isEmpty) {
       if (data.isEmpty) {
@@ -127,11 +239,21 @@ class MifareClassicGen2WriteHelper extends BaseMifareClassicWriteHelper {
     }
 
     for (var sector = 0; sector < mfClassicGetSectorCount(type); sector++) {
+      if (!operationCanContinue) return false;
       var block = mfClassicGetSectorTrailerBlockBySector(sector);
       if (data.length > block && data[block].isNotEmpty) {
-        cleanSectors[sector] = await writeBlockModifier(
+        final outcome = await writeBlockModifierOutcome(
             card, block, data[block],
             tryBothKeys: true);
+        switch (outcome) {
+          case MifareClassicMagicWriteOutcome.success:
+            cleanSectors[sector] = true;
+          case MifareClassicMagicWriteOutcome.rejected:
+            cleanSectors[sector] = false;
+          case MifareClassicMagicWriteOutcome.ambiguous:
+            return false;
+        }
+        if (!operationCanContinue) return false;
         if (cleanSectors[sector]) {
           // Update keys to match the newly written trailer,
           // so subsequent data block writes use the correct keys.
@@ -153,12 +275,24 @@ class MifareClassicGen2WriteHelper extends BaseMifareClassicWriteHelper {
         }
 
         if (data.length > blockToWrite && data[blockToWrite].isNotEmpty) {
-          if (!(await writeBlockModifier(card, blockToWrite, data[blockToWrite],
-                      useGenericKey: cleanSectors[sector], tryBothKeys: true) &&
-                  cleanSectors[sector]) &&
-              blockToWrite != 0) {
+          if (!operationCanContinue) return false;
+          final outcome = await writeBlockModifierOutcome(
+              card, blockToWrite, data[blockToWrite],
+              useGenericKey: cleanSectors[sector], tryBothKeys: true);
+          late final bool writeSucceeded;
+          switch (outcome) {
+            case MifareClassicMagicWriteOutcome.success:
+              writeSucceeded = true;
+            case MifareClassicMagicWriteOutcome.rejected:
+              writeSucceeded = false;
+            case MifareClassicMagicWriteOutcome.ambiguous:
+              return false;
+          }
+          if (!(writeSucceeded && cleanSectors[sector]) && blockToWrite != 0) {
             failedBlocks.add(blockToWrite);
           }
+
+          if (!operationCanContinue) return false;
 
           update((blockToWrite / mfClassicGetBlockCount(type) * 100).round());
         }
@@ -166,15 +300,28 @@ class MifareClassicGen2WriteHelper extends BaseMifareClassicWriteHelper {
     }
 
     for (var sector = 0; sector < mfClassicGetSectorCount(type); sector++) {
+      if (!operationCanContinue) return false;
       var block = mfClassicGetSectorTrailerBlockBySector(sector);
       if (cleanSectors[sector] &&
           data.length > block &&
           data[block].isNotEmpty) {
-        if (!(await writeBlockModifier(card, block, data[block],
-            tryBothKeys: true, useGenericKey: true))) {
-          // how we went here? We set to default sector trailer and now we can't write to it. Probably card is lost
-          return false;
+        final outcome = await writeBlockModifierOutcome(
+          card,
+          block,
+          data[block],
+          tryBothKeys: true,
+          useGenericKey: true,
+        );
+        switch (outcome) {
+          case MifareClassicMagicWriteOutcome.success:
+            break;
+          case MifareClassicMagicWriteOutcome.rejected:
+            // how we went here? We set to default sector trailer and now we can't write to it. Probably card is lost
+            return false;
+          case MifareClassicMagicWriteOutcome.ambiguous:
+            return false;
         }
+        if (!operationCanContinue) return false;
       }
     }
 

--- a/chameleonultragui/lib/helpers/mifare_classic/write/gen3.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/write/gen3.dart
@@ -18,15 +18,17 @@ class MifareClassicGen3WriteHelper extends MifareClassicGen2WriteHelper {
   @override
   Future<bool> isMagic(dynamic data) async {
     try {
+      if (!operationCanContinue) return false;
       if (!await communicator.detectMf1Support()) {
         return false; // not even Mifare Classic
       }
+      if (!operationCanContinue) return false;
 
       Uint8List response = await communicator.send14ARaw(
           Uint8List.fromList([0x30, 0x00]),
           checkResponseCrc: false);
 
-      return response.length == 18; // 16 + 2 byte CRC
+      return operationCanContinue && response.length == 18; // 16 + 2 byte CRC
     } catch (_) {
       return false;
     }
@@ -49,44 +51,81 @@ class MifareClassicGen3WriteHelper extends MifareClassicGen2WriteHelper {
   }
 
   @override
-  Future<bool> writeBlockModifier(CardSave card, int block, Uint8List data,
-      {bool tryBothKeys = false, bool useGenericKey = false}) async {
-    for (int retry = 0; retry < 10; retry++) {
-      try {
-        await Future.delayed(const Duration(milliseconds: 50)); // Stability delay
-        if (block == 0) {
-          if (await writeGen3Block(card, data)) return true;
-        } else {
-          if (await writeBlock(block, data,
-              tryBothKeys: tryBothKeys, useGenericKey: useGenericKey)) {
-            return true;
-          }
-        }
-        await Future.delayed(const Duration(milliseconds: 150));
-      } catch (_) {}
+  Future<MifareClassicMagicWriteOutcome> writeSingleBlockOutcome(
+      CardSave card, int block, Uint8List data,
+      {bool tryBothKeys = false, bool useGenericKey = false}) {
+    if (block == 0) {
+      return writeGen3BlockOutcome(card, data);
     }
-
-    return false;
+    return super.writeSingleBlockOutcome(
+      card,
+      block,
+      data,
+      tryBothKeys: tryBothKeys,
+      useGenericKey: useGenericKey,
+    );
   }
 
-  Future<bool> writeGen3Block(CardSave dump, Uint8List data) async {
+  Future<bool> writeGen3Block(CardSave dump, Uint8List data) async =>
+      (await writeGen3BlockOutcome(dump, data)).succeeded &&
+      operationCanContinue;
+
+  Future<MifareClassicMagicWriteOutcome> writeGen3BlockOutcome(
+      CardSave dump, Uint8List data) async {
+    if (!operationCanContinue) {
+      return MifareClassicMagicWriteOutcome.rejected;
+    }
     // Try to write whole block
-    await communicator.send14ARaw(
-        Uint8List.fromList([0x90, 0xFB, 0xCC, 0xCC, 0x10, ...data]),
-        checkResponseCrc: false);
+    try {
+      await communicator.send14ARaw(
+          Uint8List.fromList([0x90, 0xFB, 0xCC, 0xCC, 0x10, ...data]),
+          checkResponseCrc: false);
+    } catch (_) {
+      return MifareClassicMagicWriteOutcome.ambiguous;
+    }
 
     // Try to write UID only
-    await communicator.send14ARaw(
-        Uint8List.fromList(
-            [0x90, 0xFB, 0xCC, 0xCC, 0x07, ...hexToBytes(dump.uid)]),
-        checkResponseCrc: false);
+    if (!operationCanContinue) {
+      return MifareClassicMagicWriteOutcome.ambiguous;
+    }
+    try {
+      await communicator.send14ARaw(
+          Uint8List.fromList(
+              [0x90, 0xFB, 0xCC, 0xCC, 0x07, ...hexToBytes(dump.uid)]),
+          checkResponseCrc: false);
+    } catch (_) {
+      return MifareClassicMagicWriteOutcome.ambiguous;
+    }
+
+    if (!operationCanContinue) {
+      return MifareClassicMagicWriteOutcome.ambiguous;
+    }
 
     // Card doesn't respond with anything, just compare UID
-    await Future.delayed(const Duration(milliseconds: 500)); // Wait for card to reboot
-    CardData? card = await communicator.scan14443aTag();
-    return card != null &&
-            bytesToHex(card.uid) ==
-                bytesToHex(data.sublist(0, card.uid.length)) ||
-        card != null && bytesToHexSpace(card.uid) == dump.uid;
+    await Future.delayed(
+        const Duration(milliseconds: 500)); // Wait for card to reboot
+    if (!operationCanContinue) {
+      return MifareClassicMagicWriteOutcome.ambiguous;
+    }
+    CardData? card;
+    try {
+      card = await communicator.scan14443aTag();
+    } catch (_) {
+      return MifareClassicMagicWriteOutcome.ambiguous;
+    }
+    if (!operationCanContinue) {
+      return MifareClassicMagicWriteOutcome.ambiguous;
+    }
+    try {
+      final verified = card != null &&
+              bytesToHex(card.uid) ==
+                  bytesToHex(data.sublist(0, card.uid.length)) ||
+          card != null && bytesToHexSpace(card.uid) == dump.uid;
+      return verified
+          ? MifareClassicMagicWriteOutcome.success
+          : MifareClassicMagicWriteOutcome.ambiguous;
+    } catch (_) {
+      return MifareClassicMagicWriteOutcome.ambiguous;
+    }
   }
 }

--- a/chameleonultragui/lib/helpers/mifare_classic/write/gen3.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/write/gen3.dart
@@ -8,7 +8,8 @@ import 'package:chameleonultragui/helpers/mifare_classic/write/gen2.dart';
 import 'package:chameleonultragui/sharedprefsprovider.dart';
 
 class MifareClassicGen3WriteHelper extends MifareClassicGen2WriteHelper {
-  MifareClassicGen3WriteHelper(super.communicator, {required super.recovery});
+  MifareClassicGen3WriteHelper(super.communicator,
+      {required super.recovery, required super.operationCanContinue});
 
   @override
   String get name => "gen3";

--- a/chameleonultragui/lib/helpers/mifare_ultralight/write/base.dart
+++ b/chameleonultragui/lib/helpers/mifare_ultralight/write/base.dart
@@ -23,18 +23,27 @@ class BaseMifareUltralightWriteHelper extends AbstractWriteHelper {
   TextEditingController keyController = TextEditingController();
   String? key;
 
-  BaseMifareUltralightWriteHelper(super.communicator);
+  BaseMifareUltralightWriteHelper(super.communicator,
+      {required super.operationCanContinue});
 
   @override
   List<AbstractWriteHelper> getAvailableMethods() {
     return [
-      BaseMifareUltralightWriteHelper(communicator),
+      BaseMifareUltralightWriteHelper(
+        communicator,
+        operationCanContinue: () => operationCanContinue,
+      ),
     ];
   }
 
   @override
   List<AbstractWriteHelper> getAvailableMethodsByPriority() {
-    return [BaseMifareUltralightWriteHelper(communicator)];
+    return [
+      BaseMifareUltralightWriteHelper(
+        communicator,
+        operationCanContinue: () => operationCanContinue,
+      )
+    ];
   }
 
   @override

--- a/chameleonultragui/lib/helpers/mifare_ultralight/write/base.dart
+++ b/chameleonultragui/lib/helpers/mifare_ultralight/write/base.dart
@@ -119,27 +119,33 @@ class BaseMifareUltralightWriteHelper extends AbstractWriteHelper {
   @override
   Future<bool> writeData(
       CardSave card, Function(int writeProgress) update) async {
+    if (!operationCanContinue) return false;
     int totalBlocks = card.data.length;
 
     if (!await communicator.isReaderDeviceMode()) {
+      if (!operationCanContinue) return false;
       await communicator.setReaderDeviceMode(true);
     }
+    if (!operationCanContinue) return false;
 
     if (await communicator.scan14443aTag() == null) {
       return false;
     }
+    if (!operationCanContinue) return false;
 
     if (key!.isNotEmpty) {
+      if (!operationCanContinue) return false;
       Uint8List pack = await communicator.send14ARaw(
           Uint8List.fromList([0x1B, ...hexToBytes(key!)]),
           keepRfField: true);
-      if (pack.length < 2) {
+      if (!operationCanContinue || pack.length < 2) {
         return false;
       }
     }
 
     for (var pass = 0; pass < 2; pass++) {
       for (var block = 0; block < totalBlocks; block++) {
+        if (!operationCanContinue) return false;
         if (card.data[block].isNotEmpty) {
           List<int> blockData = List.from(card.data[block]);
 
@@ -161,13 +167,16 @@ class BaseMifareUltralightWriteHelper extends AbstractWriteHelper {
               keepRfField: true,
               checkResponseCrc: false,
               autoSelect: block == 0 || block == 3);
+          if (!operationCanContinue) return false;
           if (write.isEmpty || write[0] != 0x0A || block == 2) {
             await communicator.send14ARaw(Uint8List(1)); // reset
+            if (!operationCanContinue) return false;
 
             if (key!.isNotEmpty) {
               await communicator.send14ARaw(
                   Uint8List.fromList([0x1B, ...hexToBytes(key!)]),
                   keepRfField: true);
+              if (!operationCanContinue) return false;
             }
 
             if (block > 2) {
@@ -176,12 +185,13 @@ class BaseMifareUltralightWriteHelper extends AbstractWriteHelper {
             }
           }
 
+          if (!operationCanContinue) return false;
           update((block / (totalBlocks + 2) * 100).round());
         }
       }
     }
 
-    return failedBlocks.isEmpty;
+    return operationCanContinue && failedBlocks.isEmpty;
   }
 
   @override

--- a/chameleonultragui/lib/helpers/mifare_ultralight/write/base.dart
+++ b/chameleonultragui/lib/helpers/mifare_ultralight/write/base.dart
@@ -168,7 +168,11 @@ class BaseMifareUltralightWriteHelper extends AbstractWriteHelper {
               checkResponseCrc: false,
               autoSelect: block == 0 || block == 3);
           if (!operationCanContinue) return false;
-          if (write.isEmpty || write[0] != 0x0A || block == 2) {
+          if (write.length != 1 || write.single != 0x0A) {
+            return false;
+          }
+
+          if (block == 2) {
             await communicator.send14ARaw(Uint8List(1)); // reset
             if (!operationCanContinue) return false;
 
@@ -177,11 +181,6 @@ class BaseMifareUltralightWriteHelper extends AbstractWriteHelper {
                   Uint8List.fromList([0x1B, ...hexToBytes(key!)]),
                   keepRfField: true);
               if (!operationCanContinue) return false;
-            }
-
-            if (block > 2) {
-              // block is not UID
-              failedBlocks.add(block);
             }
           }
 

--- a/chameleonultragui/lib/helpers/rf_operation_coordinator.dart
+++ b/chameleonultragui/lib/helpers/rf_operation_coordinator.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+import 'dart:collection';
+
+class RfBackgroundResult<T> {
+  const RfBackgroundResult._({required this.acquired, this.value});
+
+  const RfBackgroundResult.skipped() : this._(acquired: false);
+
+  const RfBackgroundResult.completed(T value)
+      : this._(acquired: true, value: value);
+
+  final bool acquired;
+  final T? value;
+}
+
+class RfOperationCoordinator {
+  final Queue<Future<void> Function()> _foregroundQueue = Queue();
+  bool _active = false;
+
+  Future<T> runForeground<T>(Future<T> Function() operation) {
+    final result = Completer<T>();
+    _foregroundQueue.add(() async {
+      try {
+        result.complete(await operation());
+      } catch (error, stackTrace) {
+        result.completeError(error, stackTrace);
+      } finally {
+        _release();
+      }
+    });
+    _startNextForeground();
+    return result.future;
+  }
+
+  Future<RfBackgroundResult<T>> tryRunBackground<T>(
+    Future<T> Function() operation,
+  ) async {
+    if (_active || _foregroundQueue.isNotEmpty) {
+      return const RfBackgroundResult.skipped();
+    }
+
+    _active = true;
+    try {
+      return RfBackgroundResult.completed(await operation());
+    } finally {
+      _release();
+    }
+  }
+
+  void _startNextForeground() {
+    if (_active || _foregroundQueue.isEmpty) {
+      return;
+    }
+
+    _active = true;
+    unawaited(_foregroundQueue.removeFirst()());
+  }
+
+  void _release() {
+    _active = false;
+    _startNextForeground();
+  }
+}

--- a/chameleonultragui/lib/helpers/t55xx/write/base.dart
+++ b/chameleonultragui/lib/helpers/t55xx/write/base.dart
@@ -30,13 +30,13 @@ class BaseT55XXCardHelper extends AbstractWriteHelper {
   @override
   List<AbstractWriteHelper> getAvailableMethods() {
     return [
-      BaseT55XXCardHelper(communicator),
+      inheritOperationContinuation(BaseT55XXCardHelper(communicator)),
     ];
   }
 
   @override
   List<AbstractWriteHelper> getAvailableMethodsByPriority() {
-    return [BaseT55XXCardHelper(communicator)];
+    return [inheritOperationContinuation(BaseT55XXCardHelper(communicator))];
   }
 
   @override
@@ -146,35 +146,46 @@ class BaseT55XXCardHelper extends AbstractWriteHelper {
   @override
   Future<bool> writeData(
       CardSave card, Function(int writeProgress) update) async {
+    if (!operationCanContinue) return false;
     if (isEM410X(card.tag)) {
       await communicator.writeEM410XtoT55XX(hexToBytes(card.uid),
           hexToBytes(newKey), [hexToBytes(currentKey), Uint8List(4)]);
+      if (!operationCanContinue) return false;
+      // A write may have reached the tag. Keep only its safety read-back.
       await Future.delayed(const Duration(milliseconds: 500));
+      if (!operationCanContinue) return false;
       var newCard = await communicator.readEM410X();
-      return newCard.toString() == card.uid;
+      return operationCanContinue && newCard.toString() == card.uid;
     } else if (card.tag == TagType.hidProx) {
       await communicator.writeHIDProxToT55XX(hexToBytes(card.uid),
           hexToBytes(newKey), [hexToBytes(currentKey), Uint8List(4)]);
+      if (!operationCanContinue) return false;
       await Future.delayed(const Duration(milliseconds: 500));
+      if (!operationCanContinue) return false;
       var newCard = await communicator.readHIDProx();
-      return newCard.toString() == card.uid;
+      return operationCanContinue && newCard.toString() == card.uid;
     } else if (card.tag == TagType.viking) {
       await communicator.writeVikingToT55XX(hexToBytes(card.uid),
           hexToBytes(newKey), [hexToBytes(currentKey), Uint8List(4)]);
+      if (!operationCanContinue) return false;
       await Future.delayed(const Duration(milliseconds: 500));
+      if (!operationCanContinue) return false;
       var newCard = await communicator.readViking();
-      return newCard.toString() == card.uid;
+      return operationCanContinue && newCard.toString() == card.uid;
     } else if (card.tag == TagType.pac) {
       await communicator.writePacToT55XX(hexToBytes(card.uid),
           hexToBytes(newKey), [hexToBytes(currentKey), Uint8List(4)]);
+      if (!operationCanContinue) return false;
       var newCard = await communicator.readPac();
-      return newCard.toString() == card.uid;
+      return operationCanContinue && newCard.toString() == card.uid;
     } else if (card.tag == TagType.ioProx) {
       await communicator.writeIoProxToT55XX(hexToBytes(card.uid),
           hexToBytes(newKey), [hexToBytes(currentKey), Uint8List(4)]);
+      if (!operationCanContinue) return false;
       await Future.delayed(const Duration(milliseconds: 500));
+      if (!operationCanContinue) return false;
       var newCard = await communicator.readIoProx();
-      return newCard.toString() == card.uid;
+      return operationCanContinue && newCard.toString() == card.uid;
     } else if (card.tag == TagType.idteck) {
       await communicator.writeIdteckToT55XX(hexToBytes(card.uid),
           hexToBytes(newKey), [hexToBytes(currentKey), Uint8List(4)]);
@@ -182,7 +193,7 @@ class BaseT55XXCardHelper extends AbstractWriteHelper {
       // on the envelope-only tag-emulation ADC path is a follow-up), so we
       // cannot read back the tag for verification. Assume the T55xx write
       // succeeded if the firmware did not raise an error.
-      return true;
+      return operationCanContinue;
     }
 
     return false;

--- a/chameleonultragui/lib/helpers/t55xx/write/base.dart
+++ b/chameleonultragui/lib/helpers/t55xx/write/base.dart
@@ -25,18 +25,27 @@ class BaseT55XXCardHelper extends AbstractWriteHelper {
   String currentKey = "";
   String newKey = "";
 
-  BaseT55XXCardHelper(super.communicator);
+  BaseT55XXCardHelper(super.communicator,
+      {required super.operationCanContinue});
 
   @override
   List<AbstractWriteHelper> getAvailableMethods() {
     return [
-      inheritOperationContinuation(BaseT55XXCardHelper(communicator)),
+      inheritOperationContinuation(BaseT55XXCardHelper(
+        communicator,
+        operationCanContinue: () => operationCanContinue,
+      )),
     ];
   }
 
   @override
   List<AbstractWriteHelper> getAvailableMethodsByPriority() {
-    return [inheritOperationContinuation(BaseT55XXCardHelper(communicator))];
+    return [
+      inheritOperationContinuation(BaseT55XXCardHelper(
+        communicator,
+        operationCanContinue: () => operationCanContinue,
+      ))
+    ];
   }
 
   @override

--- a/chameleonultragui/lib/helpers/write.dart
+++ b/chameleonultragui/lib/helpers/write.dart
@@ -16,6 +16,19 @@ abstract class AbstractWriteHelper {
   final ChameleonCommunicator communicator;
   AbstractWriteHelper(this.communicator);
 
+  bool Function()? _operationCanContinue;
+
+  void setOperationContinuation(bool Function() canContinue) {
+    _operationCanContinue = canContinue;
+  }
+
+  bool get operationCanContinue => _operationCanContinue?.call() ?? true;
+
+  T inheritOperationContinuation<T extends AbstractWriteHelper>(T helper) {
+    helper.setOperationContinuation(() => operationCanContinue);
+    return helper;
+  }
+
   bool readSupported = false; // can read data without authorization
   bool writeSupported = false; // can write data without authorization
 

--- a/chameleonultragui/lib/helpers/write.dart
+++ b/chameleonultragui/lib/helpers/write.dart
@@ -14,15 +14,18 @@ import 'package:flutter/material.dart';
 
 abstract class AbstractWriteHelper {
   final ChameleonCommunicator communicator;
-  AbstractWriteHelper(this.communicator);
+  bool Function() _operationCanContinue;
 
-  bool Function()? _operationCanContinue;
+  AbstractWriteHelper(
+    this.communicator, {
+    required bool Function() operationCanContinue,
+  }) : _operationCanContinue = operationCanContinue;
 
   void setOperationContinuation(bool Function() canContinue) {
     _operationCanContinue = canContinue;
   }
 
-  bool get operationCanContinue => _operationCanContinue?.call() ?? true;
+  bool get operationCanContinue => _operationCanContinue();
 
   T inheritOperationContinuation<T extends AbstractWriteHelper>(T helper) {
     helper.setOperationContinuation(() => operationCanContinue);
@@ -61,9 +64,16 @@ abstract class AbstractWriteHelper {
       TagType type,
       ChameleonGUIState appState,
       void Function() update,
-      AppLocalizations localizations) {
+      AppLocalizations localizations,
+      {required bool Function() operationCanContinue}) {
+    final communicator = appState.communicator;
+    if (communicator == null) {
+      return null;
+    }
+
     if (isMifareClassic(type)) {
-      return BaseMifareClassicWriteHelper(appState.communicator!,
+      return BaseMifareClassicWriteHelper(communicator,
+          operationCanContinue: operationCanContinue,
           recovery: MifareClassicRecovery(
               appState: appState,
               update: update,
@@ -71,7 +81,10 @@ abstract class AbstractWriteHelper {
     }
 
     if (isMifareUltralight(type)) {
-      return BaseMifareUltralightWriteHelper(appState.communicator!);
+      return BaseMifareUltralightWriteHelper(
+        communicator,
+        operationCanContinue: operationCanContinue,
+      );
     }
 
     if (isEM410X(type) ||
@@ -80,7 +93,10 @@ abstract class AbstractWriteHelper {
         type == TagType.pac ||
         type == TagType.ioProx ||
         type == TagType.idteck) {
-      return BaseT55XXCardHelper(appState.communicator!);
+      return BaseT55XXCardHelper(
+        communicator,
+        operationCanContinue: operationCanContinue,
+      );
     }
 
     return null; // writing is not supported

--- a/chameleonultragui/lib/main.dart
+++ b/chameleonultragui/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:chameleonultragui/connector/serial_macos.dart';
 import 'package:chameleonultragui/gui/page/tools.dart';
 import 'package:chameleonultragui/helpers/font.dart';
 import 'package:chameleonultragui/helpers/general.dart';
+import 'package:chameleonultragui/helpers/rf_operation_coordinator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
@@ -65,6 +66,8 @@ class ChameleonGUI extends StatelessWidget {
 class ChameleonGUIState extends ChangeNotifier {
   final SharedPreferencesProvider sharedPreferencesProvider;
   ChameleonGUIState(this.sharedPreferencesProvider);
+
+  final RfOperationCoordinator rfOperations = RfOperationCoordinator();
 
   SharedPreferencesProvider? _sharedPreferencesProvider;
   Logger? log; // Logger
@@ -134,6 +137,12 @@ class ChameleonGUIState extends ChangeNotifier {
   void setProgressBar(dynamic value) {
     progress = value;
     notifyListeners();
+  }
+
+  bool hasConnectedCommunicator(ChameleonCommunicator candidate) {
+    return connector?.connected == true &&
+        connector?.isDFU != true &&
+        identical(communicator, candidate);
   }
 }
 

--- a/chameleonultragui/test/ambiguous_write_safety_test.dart
+++ b/chameleonultragui/test/ambiguous_write_safety_test.dart
@@ -1,16 +1,21 @@
 import 'dart:typed_data';
 
 import 'package:chameleonultragui/bridge/chameleon.dart';
+import 'package:chameleonultragui/connector/serial_abstract.dart';
 import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
+import 'package:chameleonultragui/gui/menu/tools/t55xx_password_cleaner.dart';
 import 'package:chameleonultragui/helpers/definitions.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/recovery.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/write/gen1.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/write/gen2.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/write/gen3.dart';
+import 'package:chameleonultragui/helpers/t55xx/write/base.dart';
 import 'package:chameleonultragui/main.dart';
 import 'package:chameleonultragui/sharedprefsprovider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:logger/logger.dart';
+import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -33,10 +38,86 @@ void main() {
     );
   }
 
+  test('Gen1 does not retry a block after an issued write loses its response',
+      () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    final communicator = _AmbiguousWriteCommunicator(logger);
+    final helper = MifareClassicGen1WriteHelper(
+      communicator,
+      recovery: await recoveryFor(communicator),
+    );
+
+    final result = await helper.writeBlock(1, Uint8List(16));
+
+    expect(result, isFalse);
+    expect(communicator.classicRawWrites, 1);
+  });
+
+  test('Gen1 does not retry a block after an empty write response', () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    final communicator = _AmbiguousWriteCommunicator(
+      logger,
+      emptyClassicWriteResponse: true,
+    );
+    final helper = MifareClassicGen1WriteHelper(
+      communicator,
+      recovery: await recoveryFor(communicator),
+    );
+
+    final result = await helper.writeBlock(1, Uint8List(16));
+
+    expect(result, isFalse);
+    expect(communicator.classicRawWrites, 1);
+  });
+
+  test('Gen1 may retry an explicit write rejection', () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    final communicator = _AmbiguousWriteCommunicator(
+      logger,
+      rejectFirstClassicWrite: true,
+    );
+    final helper = MifareClassicGen1WriteHelper(
+      communicator,
+      recovery: await recoveryFor(communicator),
+    );
+
+    final result = await helper.writeBlock(1, Uint8List(16));
+
+    expect(result, isTrue);
+    expect(communicator.classicRawWrites, 2);
+  });
+
+  test('Gen2 does not try another key after an issued write loses its response',
+      () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    final communicator = _AmbiguousWriteCommunicator(logger);
+    final helper = MifareClassicGen2WriteHelper(
+      communicator,
+      recovery: await recoveryFor(communicator),
+    );
+
+    final result = await helper.writeBlockModifier(
+      _classicCard(),
+      1,
+      Uint8List(16),
+      tryBothKeys: true,
+    );
+
+    expect(result, isFalse);
+    expect(communicator.authenticatedWrites, 1);
+  });
+
   test('Gen2 full write stops after an ambiguous trailer write', () async {
     final logger = Logger(output: MemoryOutput());
     addTearDown(logger.close);
-    final communicator = _WriteCommunicator(logger, returnScannedCard: true);
+    final communicator = _AmbiguousWriteCommunicator(
+      logger,
+      returnScannedCard: true,
+    );
     final helper = MifareClassicGen2WriteHelper(
       communicator,
       recovery: await recoveryFor(communicator),
@@ -56,10 +137,11 @@ void main() {
     expect(communicator.authenticatedWrites, 1);
   });
 
-  test('Gen2 may try another key after an explicit rejection', () async {
+  test('Gen2 full write may try another key after an explicit rejection',
+      () async {
     final logger = Logger(output: MemoryOutput());
     addTearDown(logger.close);
-    final communicator = _WriteCommunicator(
+    final communicator = _AmbiguousWriteCommunicator(
       logger,
       returnScannedCard: true,
       rejectFirstAuthenticatedWrite: true,
@@ -69,17 +151,42 @@ void main() {
       recovery: await recoveryFor(communicator),
     );
 
-    expect(
-      await helper.writeData(_classicCard([Uint8List(16)]), (_) {}),
-      isTrue,
+    final result = await helper.writeData(
+      _classicCard([Uint8List(16)]),
+      (_) {},
     );
+
+    expect(result, isTrue);
     expect(communicator.authenticatedWrites, 2);
+  });
+
+  test('Gen3 does not retry block 0 after an issued write loses its response',
+      () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    final communicator = _AmbiguousWriteCommunicator(logger);
+    final helper = MifareClassicGen3WriteHelper(
+      communicator,
+      recovery: await recoveryFor(communicator),
+    );
+
+    final result = await helper.writeBlockModifier(
+      _classicCard(),
+      0,
+      Uint8List(16),
+    );
+
+    expect(result, isFalse);
+    expect(communicator.gen3Writes, 1);
   });
 
   test('Gen3 full write stops after an ambiguous block-zero write', () async {
     final logger = Logger(output: MemoryOutput());
     addTearDown(logger.close);
-    final communicator = _WriteCommunicator(logger, returnScannedCard: true);
+    final communicator = _AmbiguousWriteCommunicator(
+      logger,
+      returnScannedCard: true,
+    );
     final helper = MifareClassicGen3WriteHelper(
       communicator,
       recovery: await recoveryFor(communicator),
@@ -98,14 +205,14 @@ void main() {
     expect(communicator.authenticatedWrites, 0);
   });
 
-  test('Gen3 stops before the next block and resets for a later write',
+  test('Gen3 stops before the next block and resets for a later full write',
       () async {
     final logger = Logger(output: MemoryOutput());
     addTearDown(logger.close);
-    final communicator = _WriteCommunicator(
+    final communicator = _AmbiguousWriteCommunicator(
       logger,
-      returnScannedCard: true,
       completeGen3Write: true,
+      returnScannedCard: true,
     );
     final helper = MifareClassicGen3WriteHelper(
       communicator,
@@ -131,37 +238,215 @@ void main() {
     expect(ambiguousResult, isFalse);
     expect(communicator.authenticatedWrites, 1);
 
-    final laterResult = await helper.writeData(
+    final verifiedResult = await helper.writeData(
       _classicCard([verifiedBlockZero]),
       (_) {},
     );
 
-    expect(laterResult, isTrue);
+    expect(verifiedResult, isTrue);
     expect(communicator.authenticatedWrites, 1);
     expect(communicator.gen3Writes, 4);
   });
+
+  test('Gen3 skips read-back after its captured session becomes stale',
+      () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    var sessionCurrent = true;
+    final communicator = _AmbiguousWriteCommunicator(
+      logger,
+      completeGen3Write: true,
+      afterGen3Write: () => sessionCurrent = false,
+    );
+    final helper = MifareClassicGen3WriteHelper(
+      communicator,
+      recovery: await recoveryFor(communicator),
+    )..setOperationContinuation(() => sessionCurrent);
+
+    final result = await helper.writeBlockModifier(
+      _classicCard(),
+      0,
+      Uint8List(16),
+    );
+
+    expect(result, isFalse);
+    expect(communicator.gen3Writes, 1);
+    expect(communicator.scans, 0);
+  });
+
+  test('T55 helper skips stale-session read-back after an issued write',
+      () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    final communicator = _CompletedT55WriteCommunicator(logger);
+    final helper = BaseT55XXCardHelper(communicator);
+    var sessionCurrent = true;
+    helper.setOperationContinuation(() => sessionCurrent);
+    communicator.afterWrite = () => sessionCurrent = false;
+
+    final result = await helper.writeData(_em410xCard(), (_) {});
+
+    expect(result, isFalse);
+    expect(communicator.writes, 1);
+    expect(communicator.reads, 0);
+  });
+
+  testWidgets(
+      'T55 password cleaner stops after an issued write loses its response',
+      (tester) async {
+    final communicator = await _runPasswordCleaner(
+      tester,
+      (logger) => _AmbiguousT55WriteCommunicator(logger),
+    );
+
+    expect(communicator.writes, 1);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+      'T55 password cleaner stops when read-back fails after an issued write',
+      (tester) async {
+    final communicator = await _runPasswordCleaner(
+      tester,
+      (logger) => _AmbiguousT55ReadCommunicator(logger),
+    );
+
+    expect(communicator.writes, 1);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+      'T55 password cleaner stops when read-back is null after an issued write',
+      (tester) async {
+    final communicator = await _runPasswordCleaner(
+      tester,
+      (logger) => _CompletedT55WriteCommunicator(logger),
+    );
+
+    expect(communicator.writes, 1);
+    expect(communicator.reads, 1);
+    expect(tester.takeException(), isNull);
+  });
 }
 
-CardSave _classicCard(List<Uint8List> data) => CardSave(
+Future<T> _runPasswordCleaner<T extends ChameleonCommunicator>(
+  WidgetTester tester,
+  T Function(Logger logger) createCommunicator,
+) async {
+  SharedPreferences.setMockInitialValues({});
+  final preferences = SharedPreferencesProvider();
+  await preferences.load();
+  preferences.setDictionaries([
+    Dictionary(
+      id: 'test-passwords',
+      name: 'Test passwords',
+      keyLength: 8,
+      keys: [
+        Uint8List.fromList([1, 2, 3, 4]),
+        Uint8List.fromList([5, 6, 7, 8]),
+      ],
+    ),
+  ]);
+  final logger = Logger(output: MemoryOutput());
+  addTearDown(logger.close);
+  final communicator = createCommunicator(logger);
+  final connector = _TestSerial(log: logger)..connected = true;
+  final appState = ChameleonGUIState(preferences)
+    ..log = logger
+    ..connector = connector
+    ..communicator = communicator;
+
+  await tester.pumpWidget(
+    ChangeNotifierProvider<ChameleonGUIState>.value(
+      value: appState,
+      child: MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const Scaffold(body: T55XXPasswordCleanerMenu()),
+      ),
+    ),
+  );
+  await tester.tap(find.byType(DropdownButtonFormField<String>));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Test passwords').last);
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Start password reset'));
+  await tester.pumpAndSettle();
+
+  return communicator;
+}
+
+CardSave _classicCard([List<Uint8List> data = const []]) => CardSave(
       uid: '01020304',
       name: 'Classic',
       tag: TagType.mifare1K,
       data: data,
     );
 
-class _WriteCommunicator extends ChameleonCommunicator {
-  _WriteCommunicator(
+CardSave _em410xCard() => CardSave(
+      uid: '0102030405',
+      name: 'EM410X',
+      tag: TagType.em410X,
+    );
+
+class _AmbiguousWriteCommunicator extends ChameleonCommunicator {
+  _AmbiguousWriteCommunicator(
     super.log, {
-    required this.returnScannedCard,
-    this.rejectFirstAuthenticatedWrite = false,
+    this.emptyClassicWriteResponse = false,
+    this.rejectFirstClassicWrite = false,
     this.completeGen3Write = false,
+    this.afterGen3Write,
+    this.returnScannedCard = false,
+    this.rejectFirstAuthenticatedWrite = false,
   });
 
+  final bool emptyClassicWriteResponse;
+  final bool rejectFirstClassicWrite;
+  final bool completeGen3Write;
+  final void Function()? afterGen3Write;
   final bool returnScannedCard;
   final bool rejectFirstAuthenticatedWrite;
-  final bool completeGen3Write;
+  int classicRawWrites = 0;
   int authenticatedWrites = 0;
   int gen3Writes = 0;
+  int scans = 0;
+
+  @override
+  Future<Uint8List> send14ARaw(
+    Uint8List data, {
+    int respTimeoutMs = 100,
+    int? bitLen,
+    bool activateRfField = true,
+    bool waitResponse = true,
+    bool appendCrc = true,
+    bool autoSelect = true,
+    bool keepRfField = false,
+    bool checkResponseCrc = true,
+  }) async {
+    if (data.length == 16) {
+      classicRawWrites++;
+      if (emptyClassicWriteResponse) {
+        return Uint8List(0);
+      }
+      if (rejectFirstClassicWrite && classicRawWrites == 1) {
+        return Uint8List.fromList([0x00]);
+      }
+      if (rejectFirstClassicWrite) {
+        return Uint8List.fromList([0x0A]);
+      }
+      throw StateError('write response lost');
+    }
+    if (data.length > 2 && data[0] == 0x90) {
+      gen3Writes++;
+      if (completeGen3Write) {
+        afterGen3Write?.call();
+        return Uint8List(0);
+      }
+      throw StateError('write response lost');
+    }
+    return Uint8List.fromList([0x0A]);
+  }
 
   @override
   Future<bool> mf1WriteBlock(
@@ -178,35 +463,94 @@ class _WriteCommunicator extends ChameleonCommunicator {
   }
 
   @override
-  Future<Uint8List> send14ARaw(
-    Uint8List data, {
-    int respTimeoutMs = 100,
-    int? bitLen,
-    bool activateRfField = true,
-    bool waitResponse = true,
-    bool appendCrc = true,
-    bool autoSelect = true,
-    bool keepRfField = false,
-    bool checkResponseCrc = true,
-  }) async {
-    if (data.length > 2 && data[0] == 0x90) {
-      gen3Writes++;
-      if (completeGen3Write) {
-        return Uint8List(0);
-      }
-      throw StateError('write response lost');
+  Future<CardData?> scan14443aTag() async {
+    scans++;
+    if (returnScannedCard) {
+      return CardData(
+        uid: Uint8List.fromList([1, 2, 3, 4]),
+        sak: 0x08,
+        atqa: Uint8List.fromList([0x00, 0x04]),
+        ats: Uint8List(0),
+      );
     }
-    return Uint8List.fromList([0x0A]);
+    return null;
+  }
+}
+
+class _CompletedT55WriteCommunicator extends ChameleonCommunicator {
+  _CompletedT55WriteCommunicator(super.log);
+
+  int writes = 0;
+  int reads = 0;
+  void Function()? afterWrite;
+
+  @override
+  Future<void> writeEM410XtoT55XX(
+    Uint8List uid,
+    Uint8List newKey,
+    List<Uint8List> oldKeys,
+  ) async {
+    writes++;
+    afterWrite?.call();
   }
 
   @override
-  Future<CardData?> scan14443aTag() async {
-    if (!returnScannedCard) return null;
-    return CardData(
-      uid: Uint8List.fromList([1, 2, 3, 4]),
-      sak: 0x08,
-      atqa: Uint8List.fromList([0x00, 0x04]),
-      ats: Uint8List(0),
-    );
+  Future<EM410XCard?> readEM410X() async {
+    reads++;
+    return null;
   }
+}
+
+class _AmbiguousT55WriteCommunicator extends ChameleonCommunicator {
+  _AmbiguousT55WriteCommunicator(super.log);
+
+  int writes = 0;
+
+  @override
+  Future<void> writeEM410XtoT55XX(
+    Uint8List uid,
+    Uint8List newKey,
+    List<Uint8List> oldKeys,
+  ) async {
+    writes++;
+    throw StateError('write response lost');
+  }
+}
+
+class _AmbiguousT55ReadCommunicator extends ChameleonCommunicator {
+  _AmbiguousT55ReadCommunicator(super.log);
+
+  int writes = 0;
+
+  @override
+  Future<void> writeEM410XtoT55XX(
+    Uint8List uid,
+    Uint8List newKey,
+    List<Uint8List> oldKeys,
+  ) async {
+    writes++;
+  }
+
+  @override
+  Future<EM410XCard?> readEM410X() async {
+    throw StateError('read-back response lost');
+  }
+}
+
+class _TestSerial extends AbstractSerial {
+  _TestSerial({required super.log}) {
+    connectionType = ConnectionType.usb;
+  }
+
+  @override
+  Future<List<Chameleon>> availableChameleons(bool onlyDFU) async => [];
+
+  @override
+  Future<bool> connectSpecificDevice(dynamic devicePort) async => true;
+
+  @override
+  bool isManualConnectionSupported() => false;
+
+  @override
+  Future<bool> write(Uint8List command, {bool firmware = false}) async => true;
 }

--- a/chameleonultragui/test/ambiguous_write_safety_test.dart
+++ b/chameleonultragui/test/ambiguous_write_safety_test.dart
@@ -46,6 +46,7 @@ void main() {
     final helper = MifareClassicGen1WriteHelper(
       communicator,
       recovery: await recoveryFor(communicator),
+      operationCanContinue: () => true,
     );
 
     final result = await helper.writeBlock(1, Uint8List(16));
@@ -64,6 +65,7 @@ void main() {
     final helper = MifareClassicGen1WriteHelper(
       communicator,
       recovery: await recoveryFor(communicator),
+      operationCanContinue: () => true,
     );
 
     final result = await helper.writeBlock(1, Uint8List(16));
@@ -82,6 +84,7 @@ void main() {
     final helper = MifareClassicGen1WriteHelper(
       communicator,
       recovery: await recoveryFor(communicator),
+      operationCanContinue: () => true,
     );
 
     final result = await helper.writeBlock(1, Uint8List(16));
@@ -98,6 +101,7 @@ void main() {
     final helper = MifareClassicGen2WriteHelper(
       communicator,
       recovery: await recoveryFor(communicator),
+      operationCanContinue: () => true,
     );
 
     final result = await helper.writeBlockModifier(
@@ -111,6 +115,27 @@ void main() {
     expect(communicator.authenticatedWrites, 1);
   });
 
+  test('Gen2 reports a stale session after an issued write as ambiguous',
+      () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    var sessionCurrent = true;
+    final communicator = _CompletedClassicWriteCommunicator(
+      logger,
+      afterWrite: () => sessionCurrent = false,
+    );
+    final helper = _ExposedGen2WriteHelper(
+      communicator,
+      recovery: await recoveryFor(communicator),
+      operationCanContinue: () => true,
+    )..setOperationContinuation(() => sessionCurrent);
+
+    final outcome = await helper.writeAuthenticatedOutcome();
+
+    expect(outcome, MifareClassicMagicWriteOutcome.ambiguous);
+    expect(communicator.authenticatedWrites, 1);
+  });
+
   test('Gen2 full write stops after an ambiguous trailer write', () async {
     final logger = Logger(output: MemoryOutput());
     addTearDown(logger.close);
@@ -121,6 +146,7 @@ void main() {
     final helper = MifareClassicGen2WriteHelper(
       communicator,
       recovery: await recoveryFor(communicator),
+      operationCanContinue: () => true,
     );
 
     final result = await helper.writeData(
@@ -149,6 +175,7 @@ void main() {
     final helper = MifareClassicGen2WriteHelper(
       communicator,
       recovery: await recoveryFor(communicator),
+      operationCanContinue: () => true,
     );
 
     final result = await helper.writeData(
@@ -168,6 +195,7 @@ void main() {
     final helper = MifareClassicGen3WriteHelper(
       communicator,
       recovery: await recoveryFor(communicator),
+      operationCanContinue: () => true,
     );
 
     final result = await helper.writeBlockModifier(
@@ -190,6 +218,7 @@ void main() {
     final helper = MifareClassicGen3WriteHelper(
       communicator,
       recovery: await recoveryFor(communicator),
+      operationCanContinue: () => true,
     );
 
     final result = await helper.writeData(
@@ -217,6 +246,7 @@ void main() {
     final helper = MifareClassicGen3WriteHelper(
       communicator,
       recovery: await recoveryFor(communicator),
+      operationCanContinue: () => true,
     );
     final verifiedBlockZero = Uint8List.fromList([
       0x01,
@@ -261,6 +291,7 @@ void main() {
     final helper = MifareClassicGen3WriteHelper(
       communicator,
       recovery: await recoveryFor(communicator),
+      operationCanContinue: () => true,
     )..setOperationContinuation(() => sessionCurrent);
 
     final result = await helper.writeBlockModifier(
@@ -279,7 +310,10 @@ void main() {
     final logger = Logger(output: MemoryOutput());
     addTearDown(logger.close);
     final communicator = _CompletedT55WriteCommunicator(logger);
-    final helper = BaseT55XXCardHelper(communicator);
+    final helper = BaseT55XXCardHelper(
+      communicator,
+      operationCanContinue: () => true,
+    );
     var sessionCurrent = true;
     helper.setOperationContinuation(() => sessionCurrent);
     communicator.afterWrite = () => sessionCurrent = false;
@@ -498,6 +532,39 @@ class _CompletedT55WriteCommunicator extends ChameleonCommunicator {
   Future<EM410XCard?> readEM410X() async {
     reads++;
     return null;
+  }
+}
+
+class _ExposedGen2WriteHelper extends MifareClassicGen2WriteHelper {
+  _ExposedGen2WriteHelper(super.communicator,
+      {required super.recovery, required super.operationCanContinue});
+
+  Future<MifareClassicMagicWriteOutcome> writeAuthenticatedOutcome() {
+    return writeAuthenticatedBlock(
+      1,
+      0x60,
+      Uint8List.fromList(const [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+      Uint8List(16),
+    );
+  }
+}
+
+class _CompletedClassicWriteCommunicator extends ChameleonCommunicator {
+  _CompletedClassicWriteCommunicator(super.log, {required this.afterWrite});
+
+  final void Function() afterWrite;
+  int authenticatedWrites = 0;
+
+  @override
+  Future<bool> mf1WriteBlock(
+    int block,
+    int keyType,
+    Uint8List key,
+    Uint8List data,
+  ) async {
+    authenticatedWrites++;
+    afterWrite();
+    return true;
   }
 }
 

--- a/chameleonultragui/test/ambiguous_write_safety_test.dart
+++ b/chameleonultragui/test/ambiguous_write_safety_test.dart
@@ -1,0 +1,212 @@
+import 'dart:typed_data';
+
+import 'package:chameleonultragui/bridge/chameleon.dart';
+import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
+import 'package:chameleonultragui/helpers/definitions.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/recovery.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/write/gen2.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/write/gen3.dart';
+import 'package:chameleonultragui/main.dart';
+import 'package:chameleonultragui/sharedprefsprovider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<MifareClassicRecovery> recoveryFor(
+    ChameleonCommunicator communicator,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = SharedPreferencesProvider();
+    await preferences.load();
+    return MifareClassicRecovery(
+      appState: ChameleonGUIState(preferences)..communicator = communicator,
+      update: () {},
+      localizations: await AppLocalizations.delegate.load(const Locale('en')),
+      validKeys: List.generate(
+        80,
+        (_) => Uint8List.fromList(const [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+      ),
+    );
+  }
+
+  test('Gen2 full write stops after an ambiguous trailer write', () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    final communicator = _WriteCommunicator(logger, returnScannedCard: true);
+    final helper = MifareClassicGen2WriteHelper(
+      communicator,
+      recovery: await recoveryFor(communicator),
+    );
+
+    final result = await helper.writeData(
+      _classicCard([
+        Uint8List(16),
+        Uint8List(16),
+        Uint8List(16),
+        Uint8List.fromList(List.filled(16, 0xFF)),
+      ]),
+      (_) {},
+    );
+
+    expect(result, isFalse);
+    expect(communicator.authenticatedWrites, 1);
+  });
+
+  test('Gen2 may try another key after an explicit rejection', () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    final communicator = _WriteCommunicator(
+      logger,
+      returnScannedCard: true,
+      rejectFirstAuthenticatedWrite: true,
+    );
+    final helper = MifareClassicGen2WriteHelper(
+      communicator,
+      recovery: await recoveryFor(communicator),
+    );
+
+    expect(
+      await helper.writeData(_classicCard([Uint8List(16)]), (_) {}),
+      isTrue,
+    );
+    expect(communicator.authenticatedWrites, 2);
+  });
+
+  test('Gen3 full write stops after an ambiguous block-zero write', () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    final communicator = _WriteCommunicator(logger, returnScannedCard: true);
+    final helper = MifareClassicGen3WriteHelper(
+      communicator,
+      recovery: await recoveryFor(communicator),
+    );
+
+    final result = await helper.writeData(
+      _classicCard([
+        Uint8List(16),
+        Uint8List.fromList(List.filled(16, 0x01)),
+      ]),
+      (_) {},
+    );
+
+    expect(result, isFalse);
+    expect(communicator.gen3Writes, 1);
+    expect(communicator.authenticatedWrites, 0);
+  });
+
+  test('Gen3 stops before the next block and resets for a later write',
+      () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    final communicator = _WriteCommunicator(
+      logger,
+      returnScannedCard: true,
+      completeGen3Write: true,
+    );
+    final helper = MifareClassicGen3WriteHelper(
+      communicator,
+      recovery: await recoveryFor(communicator),
+    );
+    final verifiedBlockZero = Uint8List.fromList([
+      0x01,
+      0x02,
+      0x03,
+      0x04,
+      ...List.filled(12, 0),
+    ]);
+
+    final ambiguousResult = await helper.writeData(
+      _classicCard([
+        verifiedBlockZero,
+        Uint8List(16),
+        Uint8List.fromList(List.filled(16, 0x02)),
+      ]),
+      (_) {},
+    );
+
+    expect(ambiguousResult, isFalse);
+    expect(communicator.authenticatedWrites, 1);
+
+    final laterResult = await helper.writeData(
+      _classicCard([verifiedBlockZero]),
+      (_) {},
+    );
+
+    expect(laterResult, isTrue);
+    expect(communicator.authenticatedWrites, 1);
+    expect(communicator.gen3Writes, 4);
+  });
+}
+
+CardSave _classicCard(List<Uint8List> data) => CardSave(
+      uid: '01020304',
+      name: 'Classic',
+      tag: TagType.mifare1K,
+      data: data,
+    );
+
+class _WriteCommunicator extends ChameleonCommunicator {
+  _WriteCommunicator(
+    super.log, {
+    required this.returnScannedCard,
+    this.rejectFirstAuthenticatedWrite = false,
+    this.completeGen3Write = false,
+  });
+
+  final bool returnScannedCard;
+  final bool rejectFirstAuthenticatedWrite;
+  final bool completeGen3Write;
+  int authenticatedWrites = 0;
+  int gen3Writes = 0;
+
+  @override
+  Future<bool> mf1WriteBlock(
+    int block,
+    int keyType,
+    Uint8List key,
+    Uint8List data,
+  ) async {
+    authenticatedWrites++;
+    if (rejectFirstAuthenticatedWrite) {
+      return authenticatedWrites > 1;
+    }
+    throw StateError('write response lost');
+  }
+
+  @override
+  Future<Uint8List> send14ARaw(
+    Uint8List data, {
+    int respTimeoutMs = 100,
+    int? bitLen,
+    bool activateRfField = true,
+    bool waitResponse = true,
+    bool appendCrc = true,
+    bool autoSelect = true,
+    bool keepRfField = false,
+    bool checkResponseCrc = true,
+  }) async {
+    if (data.length > 2 && data[0] == 0x90) {
+      gen3Writes++;
+      if (completeGen3Write) {
+        return Uint8List(0);
+      }
+      throw StateError('write response lost');
+    }
+    return Uint8List.fromList([0x0A]);
+  }
+
+  @override
+  Future<CardData?> scan14443aTag() async {
+    if (!returnScannedCard) return null;
+    return CardData(
+      uid: Uint8List.fromList([1, 2, 3, 4]),
+      sak: 0x08,
+      atqa: Uint8List.fromList([0x00, 0x04]),
+      ats: Uint8List(0),
+    );
+  }
+}

--- a/chameleonultragui/test/ambiguous_write_safety_test.dart
+++ b/chameleonultragui/test/ambiguous_write_safety_test.dart
@@ -136,6 +136,27 @@ void main() {
     expect(communicator.authenticatedWrites, 1);
   });
 
+  test('Gen2 maps a successful direct write followed by staleness to ambiguous',
+      () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    var sessionCurrent = true;
+    final communicator = _CompletedClassicWriteCommunicator(
+      logger,
+      afterWrite: () {},
+    );
+    final helper = _CompletedModifierGen2WriteHelper(
+      communicator,
+      recovery: await recoveryFor(communicator),
+      operationCanContinue: () => sessionCurrent,
+      afterWrite: () => sessionCurrent = false,
+    );
+
+    final outcome = await helper.writeModifierOutcome();
+
+    expect(outcome, MifareClassicMagicWriteOutcome.ambiguous);
+  });
+
   test('Gen2 full write stops after an ambiguous trailer write', () async {
     final logger = Logger(output: MemoryOutput());
     addTearDown(logger.close);
@@ -565,6 +586,37 @@ class _CompletedClassicWriteCommunicator extends ChameleonCommunicator {
     authenticatedWrites++;
     afterWrite();
     return true;
+  }
+}
+
+class _CompletedModifierGen2WriteHelper extends MifareClassicGen2WriteHelper {
+  _CompletedModifierGen2WriteHelper(
+    super.communicator, {
+    required super.recovery,
+    required super.operationCanContinue,
+    required this.afterWrite,
+  });
+
+  final void Function() afterWrite;
+
+  Future<MifareClassicMagicWriteOutcome> writeModifierOutcome() {
+    return writeBlockModifierOutcome(
+      _classicCard(),
+      1,
+      Uint8List(16),
+    );
+  }
+
+  @override
+  Future<MifareClassicMagicWriteOutcome> writeSingleBlockOutcome(
+    CardSave card,
+    int block,
+    Uint8List data, {
+    bool tryBothKeys = false,
+    bool useGenericKey = false,
+  }) async {
+    afterWrite();
+    return MifareClassicMagicWriteOutcome.success;
   }
 }
 

--- a/chameleonultragui/test/connected_device_session_test.dart
+++ b/chameleonultragui/test/connected_device_session_test.dart
@@ -1,0 +1,152 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:chameleonultragui/bridge/chameleon.dart';
+import 'package:chameleonultragui/connector/serial_abstract.dart';
+import 'package:chameleonultragui/helpers/connected_device_session.dart';
+import 'package:chameleonultragui/main.dart';
+import 'package:chameleonultragui/sharedprefsprovider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+void main() {
+  test('session-bound foreground exposes the captured session and value',
+      () async {
+    final fixture = _connectedAppState();
+    addTearDown(fixture.logger.close);
+
+    final result = await fixture.appState.runSessionBoundForeground(
+      (session) async => 42,
+    );
+
+    expect(result.executed, isTrue);
+    expect(result.value, 42);
+    expect(result.session!.connector, same(fixture.connector));
+    expect(result.session!.communicator, same(fixture.communicator));
+  });
+
+  test('session-bound foreground preserves a nullable success', () async {
+    final fixture = _connectedAppState();
+    addTearDown(fixture.logger.close);
+
+    final result = await fixture.appState.runSessionBoundForeground<int?>(
+      (session) async => null,
+    );
+
+    expect(result.executed, isTrue);
+    expect(result.session, isNotNull);
+    expect(result.value, isNull);
+  });
+
+  test('session-bound foreground rejects a missing connection', () async {
+    final appState = ChameleonGUIState(SharedPreferencesProvider());
+    var callbackRan = false;
+
+    final result = await appState.runSessionBoundForeground((session) async {
+      callbackRan = true;
+      return 42;
+    });
+
+    expect(callbackRan, isFalse);
+    expect(result.executed, isFalse);
+  });
+
+  for (final invalidation in <String, void Function(_Fixture)>{
+    'connector replacement': (fixture) {
+      fixture.appState.connector = _TestSerial(log: fixture.logger)
+        ..connected = true;
+    },
+    'DFU transition': (fixture) => fixture.connector.isDFU = true,
+    'reconnect': (fixture) {
+      fixture.connector.connected = false;
+      fixture.appState.onConnectorStateChanged();
+      fixture.connector.connected = true;
+      fixture.appState.communicator = ChameleonCommunicator(
+        fixture.logger,
+        port: fixture.connector,
+      );
+    },
+  }.entries) {
+    test('queued session-bound foreground rejects ${invalidation.key}',
+        () async {
+      final fixture = _connectedAppState();
+      addTearDown(fixture.logger.close);
+      final release = Completer<void>();
+      final blocker = fixture.appState.rfOperations.runForeground(
+        () => release.future,
+      );
+      var callbackRan = false;
+      final queued = fixture.appState.runSessionBoundForeground(
+        (session) async {
+          callbackRan = true;
+          return 42;
+        },
+      );
+
+      invalidation.value(fixture);
+      release.complete();
+      await blocker;
+
+      expect(callbackRan, isFalse);
+      expect((await queued).executed, isFalse);
+    });
+  }
+
+  test('throwing callback releases the shared FIFO lease', () async {
+    final fixture = _connectedAppState();
+    addTearDown(fixture.logger.close);
+
+    await expectLater(
+      fixture.appState.runSessionBoundForeground<void>(
+        (session) async => throw StateError('boom'),
+      ),
+      throwsStateError,
+    );
+
+    final resumed = await fixture.appState.runSessionBoundForeground(
+      (session) async => 42,
+    );
+    expect(resumed.value, 42);
+  });
+}
+
+typedef _Fixture = ({
+  ChameleonGUIState appState,
+  _TestSerial connector,
+  ChameleonCommunicator communicator,
+  Logger logger,
+});
+
+_Fixture _connectedAppState() {
+  final logger = Logger(output: MemoryOutput());
+  final connector = _TestSerial(log: logger)..connected = true;
+  final communicator = ChameleonCommunicator(logger, port: connector);
+  final appState = ChameleonGUIState(SharedPreferencesProvider())
+    ..log = logger
+    ..connector = connector
+    ..communicator = communicator;
+  return (
+    appState: appState,
+    connector: connector,
+    communicator: communicator,
+    logger: logger,
+  );
+}
+
+class _TestSerial extends AbstractSerial {
+  _TestSerial({required super.log}) {
+    connectionType = ConnectionType.usb;
+  }
+
+  @override
+  Future<List<Chameleon>> availableChameleons(bool onlyDFU) async => [];
+
+  @override
+  Future<bool> connectSpecificDevice(dynamic devicePort) async => true;
+
+  @override
+  bool isManualConnectionSupported() => false;
+
+  @override
+  Future<bool> write(Uint8List command, {bool firmware = false}) async => true;
+}

--- a/chameleonultragui/test/home_session_safety_test.dart
+++ b/chameleonultragui/test/home_session_safety_test.dart
@@ -1,0 +1,209 @@
+import 'dart:async';
+
+import 'package:chameleonultragui/bridge/chameleon.dart';
+import 'package:chameleonultragui/connector/serial_emulator.dart';
+import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
+import 'package:chameleonultragui/gui/page/home.dart';
+import 'package:chameleonultragui/helpers/definitions.dart';
+import 'package:chameleonultragui/main.dart';
+import 'package:chameleonultragui/sharedprefsprovider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  testWidgets('Home status initialization waits for the foreground FIFO',
+      (tester) async {
+    final fixture = await _HomeFixture.create();
+    addTearDown(fixture.dispose);
+    final releaseLease = Completer<void>();
+    final leaseEntered = Completer<void>();
+    final lease = fixture.appState.rfOperations.runForeground(() async {
+      leaseEntered.complete();
+      await releaseLease.future;
+    });
+    await leaseEntered.future;
+
+    await fixture.mount(tester);
+    await tester.pump();
+    expect(fixture.communicator.operations, isEmpty);
+
+    releaseLease.complete();
+    await lease;
+    await tester.pumpAndSettle();
+
+    expect(
+      fixture.communicator.operations.take(6),
+      [
+        'slot-types',
+        'battery',
+        'firmware',
+        'commit',
+        'reader-mode',
+        'capabilities',
+      ],
+    );
+  });
+
+  testWidgets('Home discards a status result after session replacement',
+      (tester) async {
+    final statusStarted = Completer<void>();
+    final releaseStatus = Completer<void>();
+    final fixture = await _HomeFixture.create(
+      statusStarted: statusStarted,
+      releaseStatus: releaseStatus,
+    );
+    addTearDown(fixture.dispose);
+
+    await fixture.mount(tester);
+    await statusStarted.future;
+    final replacement = fixture.replaceCommunicator();
+    releaseStatus.complete();
+    for (var attempt = 0;
+        attempt < 20 && !replacement.operations.contains('capabilities');
+        attempt++) {
+      await tester.pump();
+    }
+    await tester.pump();
+
+    expect(fixture.communicator.operations, ['slot-types']);
+    expect(
+      replacement.operations.take(6),
+      [
+        'slot-types',
+        'battery',
+        'firmware',
+        'commit',
+        'reader-mode',
+        'capabilities',
+      ],
+    );
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+}
+
+class _HomeFixture {
+  _HomeFixture._({
+    required this.appState,
+    required this.communicator,
+    required this.connector,
+    required this.logger,
+  });
+
+  final ChameleonGUIState appState;
+  final _HomeCommunicator communicator;
+  final EmulatorSerial connector;
+  final Logger logger;
+
+  static Future<_HomeFixture> create({
+    Completer<void>? statusStarted,
+    Completer<void>? releaseStatus,
+  }) async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = SharedPreferencesProvider();
+    await preferences.load();
+    final logger = Logger(output: MemoryOutput());
+    final connector = EmulatorSerial(log: logger);
+    await connector.connectSpecificDevice('test-device');
+    final communicator = _HomeCommunicator(
+      logger,
+      port: connector,
+      statusStarted: statusStarted,
+      releaseStatus: releaseStatus,
+    );
+    final appState = ChameleonGUIState(preferences)
+      ..log = logger
+      ..connector = connector
+      ..communicator = communicator;
+    return _HomeFixture._(
+      appState: appState,
+      communicator: communicator,
+      connector: connector,
+      logger: logger,
+    );
+  }
+
+  _HomeCommunicator replaceCommunicator() {
+    final replacement = _HomeCommunicator(logger, port: connector);
+    appState.communicator = replacement;
+    appState.changesMade();
+    return replacement;
+  }
+
+  Future<void> mount(WidgetTester tester) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChameleonGUIState>.value(
+        value: appState,
+        child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const HomePage(),
+        ),
+      ),
+    );
+  }
+
+  void dispose() {
+    logger.close();
+  }
+}
+
+class _HomeCommunicator extends ChameleonCommunicator {
+  _HomeCommunicator(
+    super.logger, {
+    required super.port,
+    this.statusStarted,
+    this.releaseStatus,
+  });
+
+  final Completer<void>? statusStarted;
+  final Completer<void>? releaseStatus;
+  final List<String> operations = [];
+
+  @override
+  Future<List<SlotTypes>> getSlotTagTypes() async {
+    operations.add('slot-types');
+    statusStarted?.complete();
+    await releaseStatus?.future;
+    return List.generate(8, (_) => SlotTypes());
+  }
+
+  @override
+  Future<BatteryCharge> getBatteryCharge() async {
+    operations.add('battery');
+    return BatteryCharge(percent: 80, voltage: 3900);
+  }
+
+  @override
+  Future<FirmwareVersion> getFirmwareVersion() async {
+    operations.add('firmware');
+    return FirmwareVersion(legacyProtocol: false, version: 0x020100);
+  }
+
+  @override
+  Future<String> getGitCommitHash() async {
+    operations.add('commit');
+    return 'abcdef0';
+  }
+
+  @override
+  Future<bool> isReaderDeviceMode() async {
+    operations.add('reader-mode');
+    return false;
+  }
+
+  @override
+  Future<List<int>> getDeviceCapabilities() async {
+    operations.add('capabilities');
+    return [ChameleonCommand.setIdteckEmulatorID.value];
+  }
+
+  @override
+  Future<int> getActiveSlot() async {
+    operations.add('active-slot');
+    return 0;
+  }
+}

--- a/chameleonultragui/test/remaining_foreground_workflows_test.dart
+++ b/chameleonultragui/test/remaining_foreground_workflows_test.dart
@@ -1,0 +1,298 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:chameleonultragui/bridge/chameleon.dart';
+import 'package:chameleonultragui/connector/serial_emulator.dart';
+import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
+import 'package:chameleonultragui/gui/component/slot_changer.dart';
+import 'package:chameleonultragui/gui/menu/tools/lf_sniffing.dart';
+import 'package:chameleonultragui/gui/page/slot_manager.dart';
+import 'package:chameleonultragui/helpers/definitions.dart';
+import 'package:chameleonultragui/main.dart';
+import 'package:chameleonultragui/sharedprefsprovider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  testWidgets('Slot Manager upload holds one foreground FIFO lease',
+      (tester) async {
+    final fixture = await _WorkflowFixture.create();
+    addTearDown(fixture.dispose);
+    await fixture.mount(tester, const SlotManagerPage());
+    await tester.pumpAndSettle();
+    fixture.communicator.operations.clear();
+
+    final gate = Completer<void>();
+    final blocker = fixture.appState.rfOperations.runForeground(
+      () => gate.future,
+    );
+    final state = tester.state<SlotManagerPageState>(
+      find.byType(SlotManagerPage),
+    );
+    final upload = state.onTap(
+      CardSave(uid: '01 02 03 04 05', name: 'LF', tag: TagType.em410X),
+      (_, __) {},
+      await AppLocalizations.delegate.load(const Locale('en')),
+    );
+    await tester.pump();
+    expect(fixture.communicator.operations, isEmpty);
+
+    gate.complete();
+    await blocker;
+    await fixture.communicator.modeStarted.future;
+    expect(fixture.communicator.operations, ['mode:false']);
+    expect(
+      (await fixture.appState.rfOperations.tryRunBackground(() async {}))
+          .acquired,
+      isFalse,
+    );
+
+    fixture.communicator.allowMode.complete();
+    await upload;
+    expect(
+      fixture.communicator.operations,
+      [
+        'mode:false',
+        'enable:0:lf:true',
+        'activate:0',
+        'type:0:em410X',
+        'default:0:em410X',
+        'em410x:0102030405',
+        'name:0:lf:LF',
+        'save',
+      ],
+    );
+  });
+
+  testWidgets('Slot Manager upload stops after communicator replacement',
+      (tester) async {
+    final fixture = await _WorkflowFixture.create();
+    addTearDown(fixture.dispose);
+    await fixture.mount(tester, const SlotManagerPage());
+    await tester.pumpAndSettle();
+    fixture.communicator.operations.clear();
+
+    final state = tester.state<SlotManagerPageState>(
+      find.byType(SlotManagerPage),
+    );
+    final upload = state.onTap(
+      CardSave(uid: '01 02 03 04 05', name: 'LF', tag: TagType.em410X),
+      (_, __) {},
+      await AppLocalizations.delegate.load(const Locale('en')),
+    );
+    await fixture.communicator.modeStarted.future;
+    final replacement = fixture.replaceCommunicator();
+    fixture.communicator.allowMode.complete();
+    await upload;
+
+    expect(fixture.communicator.operations, ['mode:false']);
+    expect(replacement.operations, isEmpty);
+  });
+
+  testWidgets('Slot Changer metadata waits for its foreground FIFO turn',
+      (tester) async {
+    final fixture = await _WorkflowFixture.create();
+    addTearDown(fixture.dispose);
+    final gate = Completer<void>();
+    final blocker = fixture.appState.rfOperations.runForeground(
+      () => gate.future,
+    );
+
+    await fixture.mount(tester, const SlotChanger());
+    await tester.pump();
+    expect(fixture.communicator.operations, isEmpty);
+    gate.complete();
+    await blocker;
+    await tester.pumpAndSettle();
+
+    expect(fixture.communicator.operations, ['slot-types', 'active-slot']);
+  });
+
+  testWidgets('LF capture holds one lease and stops stale follow-up commands',
+      (tester) async {
+    final fixture = await _WorkflowFixture.create();
+    addTearDown(fixture.dispose);
+    await fixture.mount(tester, const LfSniffingMenu());
+    await tester.pump();
+    await tester.pump();
+    fixture.communicator.operations.clear();
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Capture').first);
+    await fixture.communicator.readerModeStarted.future;
+    final replacement = fixture.replaceCommunicator();
+    fixture.communicator.allowReaderMode.complete();
+    await tester.pumpAndSettle();
+
+    expect(fixture.communicator.operations, ['reader-mode']);
+    expect(replacement.operations, isEmpty);
+  });
+}
+
+class _WorkflowFixture {
+  _WorkflowFixture._({
+    required this.appState,
+    required this.communicator,
+    required this.connector,
+    required this.logger,
+  });
+
+  final ChameleonGUIState appState;
+  final _WorkflowCommunicator communicator;
+  final EmulatorSerial connector;
+  final Logger logger;
+
+  static Future<_WorkflowFixture> create() async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = SharedPreferencesProvider();
+    await preferences.load();
+    final logger = Logger(output: MemoryOutput());
+    final connector = EmulatorSerial(log: logger);
+    await connector.connectSpecificDevice('test-device');
+    final communicator = _WorkflowCommunicator(logger, port: connector);
+    final appState = ChameleonGUIState(preferences)
+      ..log = logger
+      ..connector = connector
+      ..communicator = communicator;
+    return _WorkflowFixture._(
+      appState: appState,
+      communicator: communicator,
+      connector: connector,
+      logger: logger,
+    );
+  }
+
+  _WorkflowCommunicator replaceCommunicator() {
+    final replacement = _WorkflowCommunicator(logger, port: connector);
+    appState.communicator = replacement;
+    return replacement;
+  }
+
+  Future<void> mount(WidgetTester tester, Widget home) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChameleonGUIState>.value(
+        value: appState,
+        child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: home,
+        ),
+      ),
+    );
+  }
+
+  void dispose() {
+    logger.close();
+  }
+}
+
+class _WorkflowCommunicator extends ChameleonCommunicator {
+  _WorkflowCommunicator(super.logger, {required super.port});
+
+  final List<String> operations = [];
+  final Completer<void> modeStarted = Completer<void>();
+  final Completer<void> allowMode = Completer<void>();
+  final Completer<void> readerModeStarted = Completer<void>();
+  final Completer<void> allowReaderMode = Completer<void>();
+
+  @override
+  Future<List<SlotTypes>> getSlotTagTypes() async {
+    operations.add('slot-types');
+    return List.generate(8, (_) => SlotTypes());
+  }
+
+  @override
+  Future<List<EnabledSlotInfo>> getEnabledSlots() async {
+    operations.add('enabled-slots');
+    return List.generate(8, (_) => EnabledSlotInfo());
+  }
+
+  @override
+  Future<List<SlotNames>> getSlotTagNames() async {
+    operations.add('slot-names');
+    return List.generate(8, (_) => SlotNames());
+  }
+
+  @override
+  Future<int> getActiveSlot() async {
+    operations.add('active-slot');
+    return 0;
+  }
+
+  @override
+  Future<void> setReaderDeviceMode(bool readerMode) async {
+    operations.add('mode:$readerMode');
+    if (!readerMode) {
+      modeStarted.complete();
+      await allowMode.future;
+    }
+  }
+
+  @override
+  Future<void> enableSlot(
+    int slot,
+    TagFrequency frequency,
+    bool status,
+  ) async {
+    operations.add('enable:$slot:${frequency.name}:$status');
+  }
+
+  @override
+  Future<void> activateSlot(int slot) async {
+    operations.add('activate:$slot');
+  }
+
+  @override
+  Future<void> setSlotType(int slot, TagType type) async {
+    operations.add('type:$slot:${type.name}');
+  }
+
+  @override
+  Future<void> setDefaultDataToSlot(int slot, TagType type) async {
+    operations.add('default:$slot:${type.name}');
+  }
+
+  @override
+  Future<void> setEM410XEmulatorID(Uint8List uid) async {
+    operations.add('em410x:${_hex(uid)}');
+  }
+
+  @override
+  Future<void> setSlotTagName(
+    int index,
+    String name,
+    TagFrequency frequency,
+  ) async {
+    operations.add('name:$index:${frequency.name}:$name');
+  }
+
+  @override
+  Future<void> saveSlotData() async {
+    operations.add('save');
+  }
+
+  @override
+  Future<List<int>> getDeviceCapabilities() async => [
+        ChameleonCommand.lfSniff.value,
+      ];
+
+  @override
+  Future<bool> isReaderDeviceMode() async {
+    operations.add('reader-mode');
+    readerModeStarted.complete();
+    await allowReaderMode.future;
+    return false;
+  }
+
+  @override
+  Future<Uint8List> lfSniff({int timeoutMs = 2000}) async {
+    operations.add('lf-sniff:$timeoutMs');
+    return Uint8List.fromList([0x80, 0x81, 0x82, 0x10]);
+  }
+}
+
+String _hex(Uint8List bytes) =>
+    bytes.map((byte) => byte.toRadixString(16).padLeft(2, '0')).join();

--- a/chameleonultragui/test/rf_operation_coordinator_test.dart
+++ b/chameleonultragui/test/rf_operation_coordinator_test.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+
+import 'package:chameleonultragui/helpers/rf_operation_coordinator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('background operations skip while an operation is active', () async {
+    final coordinator = RfOperationCoordinator();
+    final release = Completer<void>();
+    var operationsStarted = 0;
+
+    final first = coordinator.tryRunBackground(() async {
+      operationsStarted++;
+      await release.future;
+      return 'first';
+    });
+    await Future<void>.delayed(Duration.zero);
+
+    final skipped = await coordinator.tryRunBackground(() async {
+      operationsStarted++;
+      return 'overlap';
+    });
+
+    expect(skipped.acquired, isFalse);
+    expect(operationsStarted, 1);
+
+    release.complete();
+    expect((await first).value, 'first');
+  });
+
+  test('foreground operations are FIFO and background cannot starve them',
+      () async {
+    final coordinator = RfOperationCoordinator();
+    final releaseBackground = Completer<void>();
+    final releaseFirstForeground = Completer<void>();
+    final order = <String>[];
+
+    final background = coordinator.tryRunBackground(() async {
+      order.add('background');
+      await releaseBackground.future;
+    });
+    await Future<void>.delayed(Duration.zero);
+
+    final first = coordinator.runForeground(() async {
+      order.add('foreground-1');
+      await releaseFirstForeground.future;
+    });
+    final second = coordinator.runForeground(() async {
+      order.add('foreground-2');
+    });
+
+    expect((await coordinator.tryRunBackground(() async {})).acquired, isFalse);
+
+    releaseBackground.complete();
+    await background;
+    await Future<void>.delayed(Duration.zero);
+    expect(order, ['background', 'foreground-1']);
+
+    expect((await coordinator.tryRunBackground(() async {})).acquired, isFalse);
+
+    releaseFirstForeground.complete();
+    await first;
+    await second;
+    expect(order, ['background', 'foreground-1', 'foreground-2']);
+  });
+
+  test('throwing operations release their lease', () async {
+    final coordinator = RfOperationCoordinator();
+
+    await expectLater(
+      coordinator.tryRunBackground<void>(() async => throw StateError('boom')),
+      throwsStateError,
+    );
+    expect(await coordinator.runForeground(() async => 42), 42);
+
+    await expectLater(
+      coordinator.runForeground<void>(() async => throw StateError('boom')),
+      throwsStateError,
+    );
+    expect(
+      (await coordinator.tryRunBackground(() async => 'available')).value,
+      'available',
+    );
+  });
+}

--- a/chameleonultragui/test/write_card_session_safety_test.dart
+++ b/chameleonultragui/test/write_card_session_safety_test.dart
@@ -183,6 +183,73 @@ void main() {
     ]);
   });
 
+  for (final response in <List<int>>[
+    const [],
+    const [0x00],
+  ]) {
+    test(
+        'Ultralight stops after one destructive command when ACK is '
+        '${response.isEmpty ? 'missing' : 'invalid'}', () async {
+      final logger = Logger(output: MemoryOutput());
+      addTearDown(logger.close);
+      final communicator = _UltralightWriteCommunicator(
+        logger,
+        afterRawCommand: () {},
+        response: response,
+      );
+      final helper = BaseMifareUltralightWriteHelper(
+        communicator,
+        operationCanContinue: () => true,
+      )..key = '';
+
+      final result = await helper.writeData(_ultralightCard(), (_) {});
+
+      expect(result, isFalse);
+      expect(communicator.rawCommands, [
+        [0xA2, 0x00, 0x00, 0x00, 0x00, 0x00],
+      ]);
+    });
+  }
+
+  test('Ultralight preserves a valid write acknowledgement', () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    final communicator = _UltralightWriteCommunicator(
+      logger,
+      afterRawCommand: () {},
+      response: const [0x0A],
+    );
+    final helper = BaseMifareUltralightWriteHelper(
+      communicator,
+      operationCanContinue: () => true,
+    )..key = '';
+
+    final result = await helper.writeData(_ultralightCard(), (_) {});
+
+    expect(result, isTrue);
+    expect(communicator.rawCommands, [
+      [0xA2, 0x00, 0x00, 0x00, 0x00, 0x00],
+    ]);
+  });
+
+  test('Ultralight pre-issue rejection sends no destructive command', () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    final communicator = _UltralightWriteCommunicator(
+      logger,
+      afterRawCommand: () {},
+    );
+    final helper = BaseMifareUltralightWriteHelper(
+      communicator,
+      operationCanContinue: () => false,
+    )..key = '';
+
+    final result = await helper.writeData(_ultralightCard(), (_) {});
+
+    expect(result, isFalse);
+    expect(communicator.rawCommands, isEmpty);
+  });
+
   testWidgets('card selection waits for the RF FIFO before probing the card',
       (tester) async {
     final fixture = await _pumpWriter(tester, _PreflightCommunicator.new);
@@ -511,9 +578,14 @@ class _ClassicWriteCommunicator extends ChameleonCommunicator {
 }
 
 class _UltralightWriteCommunicator extends ChameleonCommunicator {
-  _UltralightWriteCommunicator(super.log, {required this.afterRawCommand});
+  _UltralightWriteCommunicator(
+    super.log, {
+    required this.afterRawCommand,
+    this.response = const [],
+  });
 
   final void Function() afterRawCommand;
+  final List<int> response;
   final List<List<int>> rawCommands = [];
 
   @override
@@ -541,7 +613,7 @@ class _UltralightWriteCommunicator extends ChameleonCommunicator {
   }) async {
     rawCommands.add(data.toList());
     afterRawCommand();
-    return Uint8List(0);
+    return Uint8List.fromList(response);
   }
 }
 

--- a/chameleonultragui/test/write_card_session_safety_test.dart
+++ b/chameleonultragui/test/write_card_session_safety_test.dart
@@ -1,0 +1,348 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:chameleonultragui/bridge/chameleon.dart';
+import 'package:chameleonultragui/connector/serial_abstract.dart';
+import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
+import 'package:chameleonultragui/gui/page/write_card.dart';
+import 'package:chameleonultragui/helpers/definitions.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/general.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/recovery.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/write/base.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/write/gen2.dart';
+import 'package:chameleonultragui/helpers/t55xx/write/base.dart';
+import 'package:chameleonultragui/main.dart';
+import 'package:chameleonultragui/sharedprefsprovider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+      'production T55 write skips read-back after communicator replacement',
+      (tester) async {
+    late ChameleonGUIState appState;
+    final fixture = await _pumpWriter(
+      tester,
+      (logger) => _T55WriteCommunicator(
+        logger,
+        afterWrite: () => appState.communicator = ChameleonCommunicator(logger),
+      ),
+    );
+    appState = fixture.appState;
+    final communicator = fixture.communicator as _T55WriteCommunicator;
+    fixture.state
+      ..card = _em410xCard()
+      ..helper = BaseT55XXCardHelper(
+        communicator,
+        operationCanContinue: () => true,
+      );
+
+    final write = fixture.state.writeCard();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 501));
+    await write;
+
+    expect(communicator.writes, 1);
+    expect(communicator.reads, 0);
+  });
+
+  testWidgets('production Magic write stops after a DFU transition',
+      (tester) async {
+    late _TestSerial connector;
+    final fixture = await _pumpWriter(
+      tester,
+      (logger) => _ClassicWriteCommunicator(
+        logger,
+        afterWrite: () => connector.isDFU = true,
+      ),
+    );
+    connector = fixture.connector;
+    final communicator = fixture.communicator as _ClassicWriteCommunicator;
+    final helper = MifareClassicGen2WriteHelper(
+      communicator,
+      recovery: await _recoveryFor(fixture.appState),
+      operationCanContinue: () => true,
+    )
+      ..type = MifareClassicType.m1k
+      ..isEV1 = false;
+    fixture.state
+      ..card = _classicCard()
+      ..helper = helper;
+
+    final write = fixture.state.writeCard();
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pump(const Duration(milliseconds: 200));
+    await write;
+
+    expect(communicator.writes, 1);
+  });
+
+  testWidgets('production write rejects a helper from a previous connection',
+      (tester) async {
+    final fixture = await _pumpWriter(tester, _T55WriteCommunicator.new);
+    final staleCommunicator = fixture.communicator as _T55WriteCommunicator;
+    final newConnector = _TestSerial(log: fixture.logger)..connected = true;
+    fixture.appState
+      ..connector = newConnector
+      ..communicator = ChameleonCommunicator(fixture.logger);
+    fixture.state
+      ..card = _em410xCard()
+      ..helper = BaseT55XXCardHelper(
+        staleCommunicator,
+        operationCanContinue: () => true,
+      );
+
+    final write = fixture.state.writeCard();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 501));
+    await write;
+
+    expect(staleCommunicator.writes, 0);
+  });
+
+  testWidgets('disposed production writer skips T55 read-back', (tester) async {
+    final writeIssued = Completer<void>();
+    final releaseWrite = Completer<void>();
+    final fixture = await _pumpWriter(
+      tester,
+      (logger) => _T55WriteCommunicator(
+        logger,
+        writeIssued: writeIssued,
+        releaseWrite: releaseWrite,
+      ),
+    );
+    final communicator = fixture.communicator as _T55WriteCommunicator;
+    fixture.state
+      ..card = _em410xCard()
+      ..helper = BaseT55XXCardHelper(
+        communicator,
+        operationCanContinue: () => true,
+      );
+
+    final write = fixture.state.writeCard();
+    await writeIssued.future;
+    await tester.pumpWidget(const SizedBox());
+    releaseWrite.complete();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 501));
+    await write;
+
+    expect(communicator.writes, 1);
+    expect(communicator.reads, 0);
+    expect(tester.takeException(), isNull);
+  });
+
+  test('Classic helper factory propagates its continuation predicate',
+      () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    final communicator = _ClassicWriteCommunicator(logger);
+    final preferences = await _preferences();
+    final appState = ChameleonGUIState(preferences)
+      ..communicator = communicator;
+    final baseHelper = BaseMifareClassicWriteHelper(
+      communicator,
+      recovery: await _recoveryFor(appState),
+      operationCanContinue: () => false,
+    );
+
+    final helper = baseHelper.getAvailableMethods().first;
+    final detected = await helper.isMagic(_classicCard());
+
+    expect(detected, isFalse);
+    expect(communicator.rawCommands, 0);
+  });
+}
+
+Future<_WriterFixture> _pumpWriter(
+  WidgetTester tester,
+  ChameleonCommunicator Function(Logger logger) createCommunicator,
+) async {
+  final preferences = await _preferences();
+  final logger = Logger(output: MemoryOutput());
+  addTearDown(logger.close);
+  final connector = _TestSerial(log: logger)
+    ..connected = true
+    ..device = ChameleonDevice.ultra;
+  final communicator = createCommunicator(logger);
+  final appState = ChameleonGUIState(preferences)
+    ..log = logger
+    ..connector = connector
+    ..communicator = communicator;
+
+  await tester.pumpWidget(
+    ChangeNotifierProvider<ChameleonGUIState>.value(
+      value: appState,
+      child: MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const WriteCardPage(),
+      ),
+    ),
+  );
+
+  return _WriterFixture(
+    appState: appState,
+    connector: connector,
+    communicator: communicator,
+    logger: logger,
+    state: tester.state<WriteCardPageState>(find.byType(WriteCardPage)),
+  );
+}
+
+Future<SharedPreferencesProvider> _preferences() async {
+  SharedPreferences.setMockInitialValues({});
+  final preferences = SharedPreferencesProvider();
+  await preferences.load();
+  return preferences;
+}
+
+Future<MifareClassicRecovery> _recoveryFor(
+  ChameleonGUIState appState,
+) async {
+  return MifareClassicRecovery(
+    appState: appState,
+    update: () {},
+    localizations: await AppLocalizations.delegate.load(const Locale('en')),
+    validKeys: List.generate(
+      80,
+      (_) => Uint8List.fromList(const [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+    ),
+  );
+}
+
+CardSave _classicCard() => CardSave(
+      uid: '01020304',
+      name: 'Classic',
+      tag: TagType.mifare1K,
+      data: [Uint8List(16), Uint8List(16)],
+    );
+
+CardSave _em410xCard() => CardSave(
+      uid: '0102030405',
+      name: 'EM410X',
+      tag: TagType.em410X,
+    );
+
+class _WriterFixture {
+  const _WriterFixture({
+    required this.appState,
+    required this.connector,
+    required this.communicator,
+    required this.logger,
+    required this.state,
+  });
+
+  final ChameleonGUIState appState;
+  final _TestSerial connector;
+  final ChameleonCommunicator communicator;
+  final Logger logger;
+  final WriteCardPageState state;
+}
+
+class _T55WriteCommunicator extends ChameleonCommunicator {
+  _T55WriteCommunicator(
+    super.log, {
+    this.afterWrite,
+    this.writeIssued,
+    this.releaseWrite,
+  });
+
+  final void Function()? afterWrite;
+  final Completer<void>? writeIssued;
+  final Completer<void>? releaseWrite;
+  int writes = 0;
+  int reads = 0;
+
+  @override
+  Future<bool> isReaderDeviceMode() async => true;
+
+  @override
+  Future<void> writeEM410XtoT55XX(
+    Uint8List uid,
+    Uint8List newKey,
+    List<Uint8List> oldKeys,
+  ) async {
+    writes++;
+    afterWrite?.call();
+    writeIssued?.complete();
+    await releaseWrite?.future;
+  }
+
+  @override
+  Future<EM410XCard?> readEM410X() async {
+    reads++;
+    return null;
+  }
+}
+
+class _ClassicWriteCommunicator extends ChameleonCommunicator {
+  _ClassicWriteCommunicator(super.log, {this.afterWrite});
+
+  final void Function()? afterWrite;
+  int writes = 0;
+  int rawCommands = 0;
+
+  @override
+  Future<bool> isReaderDeviceMode() async => true;
+
+  @override
+  Future<CardData?> scan14443aTag() async => CardData(
+        uid: Uint8List.fromList([1, 2, 3, 4]),
+        sak: 0x08,
+        atqa: Uint8List.fromList([0x00, 0x04]),
+        ats: Uint8List(0),
+      );
+
+  @override
+  Future<bool> mf1WriteBlock(
+    int block,
+    int keyType,
+    Uint8List key,
+    Uint8List data,
+  ) async {
+    writes++;
+    afterWrite?.call();
+    return true;
+  }
+
+  @override
+  Future<Uint8List> send14ARaw(
+    Uint8List data, {
+    int respTimeoutMs = 100,
+    int? bitLen,
+    bool activateRfField = true,
+    bool waitResponse = true,
+    bool appendCrc = true,
+    bool autoSelect = true,
+    bool keepRfField = false,
+    bool checkResponseCrc = true,
+  }) async {
+    rawCommands++;
+    return Uint8List.fromList([0x0A]);
+  }
+}
+
+class _TestSerial extends AbstractSerial {
+  _TestSerial({required super.log}) {
+    connectionType = ConnectionType.usb;
+  }
+
+  @override
+  Future<List<Chameleon>> availableChameleons(bool onlyDFU) async => [];
+
+  @override
+  Future<bool> connectSpecificDevice(dynamic devicePort) async => true;
+
+  @override
+  bool isManualConnectionSupported() => false;
+
+  @override
+  Future<bool> write(Uint8List command, {bool firmware = false}) async => true;
+}

--- a/chameleonultragui/test/write_card_session_safety_test.dart
+++ b/chameleonultragui/test/write_card_session_safety_test.dart
@@ -5,11 +5,14 @@ import 'package:chameleonultragui/bridge/chameleon.dart';
 import 'package:chameleonultragui/connector/serial_abstract.dart';
 import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
 import 'package:chameleonultragui/gui/page/write_card.dart';
+import 'package:chameleonultragui/helpers/connected_device_session.dart';
 import 'package:chameleonultragui/helpers/definitions.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/general.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/recovery.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/write/base.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/write/gen1.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/write/gen2.dart';
+import 'package:chameleonultragui/helpers/mifare_ultralight/write/base.dart';
 import 'package:chameleonultragui/helpers/t55xx/write/base.dart';
 import 'package:chameleonultragui/main.dart';
 import 'package:chameleonultragui/sharedprefsprovider.dart';
@@ -157,6 +160,177 @@ void main() {
     expect(detected, isFalse);
     expect(communicator.rawCommands, 0);
   });
+
+  test('Ultralight stops after its first raw command invalidates the session',
+      () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    var sessionCurrent = true;
+    final communicator = _UltralightWriteCommunicator(
+      logger,
+      afterRawCommand: () => sessionCurrent = false,
+    );
+    final helper = BaseMifareUltralightWriteHelper(
+      communicator,
+      operationCanContinue: () => sessionCurrent,
+    )..key = '';
+
+    final result = await helper.writeData(_ultralightCard(), (_) {});
+
+    expect(result, isFalse);
+    expect(communicator.rawCommands, [
+      [0xA2, 0x00, 0x00, 0x00, 0x00, 0x00],
+    ]);
+  });
+
+  testWidgets('card selection waits for the RF FIFO before probing the card',
+      (tester) async {
+    final fixture = await _pumpWriter(tester, _PreflightCommunicator.new);
+    final communicator = fixture.communicator as _PreflightCommunicator;
+    final leaseEntered = Completer<void>();
+    final releaseLease = Completer<void>();
+    final lease = fixture.appState.runSessionBoundForeground((_) async {
+      leaseEntered.complete();
+      await releaseLease.future;
+    });
+    await leaseEntered.future;
+    final localizations =
+        await AppLocalizations.delegate.load(const Locale('en'));
+
+    final selection = fixture.state.onTap(
+      _classicCard(),
+      (BuildContext _, String __) {},
+      localizations,
+    );
+    await tester.pump();
+
+    expect(communicator.supportChecks, 0);
+
+    releaseLease.complete();
+    await lease;
+    await selection;
+
+    expect(communicator.supportChecks, 1);
+  });
+
+  testWidgets('magic auto-detect rejects a stale queued session',
+      (tester) async {
+    final fixture = await _pumpWriter(tester, _PreflightCommunicator.new);
+    final communicator = fixture.communicator as _PreflightCommunicator;
+    final recovery = await _recoveryFor(fixture.appState);
+    fixture.state
+      ..card = _classicCard()
+      ..baseHelper = BaseMifareClassicWriteHelper(
+        communicator,
+        recovery: recovery,
+        operationCanContinue: () => true,
+      )
+      ..helper = MifareClassicGen2WriteHelper(
+        communicator,
+        recovery: recovery,
+        operationCanContinue: () => true,
+      );
+    final originalHelper = fixture.state.helper;
+    final leaseEntered = Completer<void>();
+    final releaseLease = Completer<void>();
+    final lease = fixture.appState.runSessionBoundForeground((_) async {
+      leaseEntered.complete();
+      await releaseLease.future;
+    });
+    await leaseEntered.future;
+
+    final detection = fixture.state.detectMagicType();
+    await tester.pump();
+    fixture.appState.communicator = ChameleonCommunicator(fixture.logger);
+    releaseLease.complete();
+    await lease;
+    await detection;
+
+    expect(communicator.rawCommands, isEmpty);
+    expect(fixture.state.helper, same(originalHelper));
+  });
+
+  testWidgets('compatibility preflight waits for the RF FIFO', (tester) async {
+    final fixture = await _pumpWriter(tester, _PreflightCommunicator.new);
+    final communicator = fixture.communicator as _PreflightCommunicator;
+    final helper = MifareClassicGen1WriteHelper(
+      communicator,
+      recovery: await _recoveryFor(fixture.appState),
+      operationCanContinue: () => true,
+    );
+    fixture.state
+      ..step = 2
+      ..card = _classicCard()
+      ..helper = helper;
+    final leaseEntered = Completer<void>();
+    final releaseLease = Completer<void>();
+    final lease = fixture.appState.runSessionBoundForeground((_) async {
+      leaseEntered.complete();
+      await releaseLease.future;
+    });
+    await leaseEntered.future;
+
+    fixture.state.onStepContinue();
+    await tester.pump();
+
+    expect(communicator.scans, 0);
+
+    releaseLease.complete();
+    await lease;
+    await tester.pumpAndSettle();
+
+    expect(communicator.scans, 1);
+  });
+
+  test('Classic card type probe stops when its session becomes stale',
+      () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    var sessionCurrent = true;
+    final communicator = _PreflightCommunicator(
+      logger,
+      supportsClassic: true,
+      afterSupportCheck: () => sessionCurrent = false,
+    );
+    final preferences = await _preferences();
+    final appState = ChameleonGUIState(preferences)
+      ..communicator = communicator;
+    final helper = BaseMifareClassicWriteHelper(
+      communicator,
+      recovery: await _recoveryFor(appState),
+      operationCanContinue: () => sessionCurrent,
+    );
+
+    await helper.getCardType();
+
+    expect(communicator.supportChecks, 1);
+    expect(communicator.scans, 0);
+    expect(communicator.rawCommands, isEmpty);
+  });
+
+  test('Classic compatibility stops before auth after a stale scan', () async {
+    final logger = Logger(output: MemoryOutput());
+    addTearDown(logger.close);
+    var sessionCurrent = true;
+    final communicator = _PreflightCommunicator(
+      logger,
+      afterScan: () => sessionCurrent = false,
+    );
+    final preferences = await _preferences();
+    final appState = ChameleonGUIState(preferences)
+      ..communicator = communicator;
+    final helper = MifareClassicGen1WriteHelper(
+      communicator,
+      recovery: await _recoveryFor(appState),
+      operationCanContinue: () => sessionCurrent,
+    );
+
+    final compatible = await helper.isCompatible(_classicCard());
+
+    expect(compatible, isFalse);
+    expect(communicator.scans, 1);
+    expect(communicator.rawCommands, isEmpty);
+  });
 }
 
 Future<_WriterFixture> _pumpWriter(
@@ -228,6 +402,13 @@ CardSave _em410xCard() => CardSave(
       uid: '0102030405',
       name: 'EM410X',
       tag: TagType.em410X,
+    );
+
+CardSave _ultralightCard() => CardSave(
+      uid: '01020304',
+      name: 'Ultralight',
+      tag: TagType.ultralight,
+      data: [Uint8List(4)],
     );
 
 class _WriterFixture {
@@ -326,6 +507,101 @@ class _ClassicWriteCommunicator extends ChameleonCommunicator {
   }) async {
     rawCommands++;
     return Uint8List.fromList([0x0A]);
+  }
+}
+
+class _UltralightWriteCommunicator extends ChameleonCommunicator {
+  _UltralightWriteCommunicator(super.log, {required this.afterRawCommand});
+
+  final void Function() afterRawCommand;
+  final List<List<int>> rawCommands = [];
+
+  @override
+  Future<bool> isReaderDeviceMode() async => true;
+
+  @override
+  Future<CardData?> scan14443aTag() async => CardData(
+        uid: Uint8List.fromList([1, 2, 3, 4]),
+        sak: 0,
+        atqa: Uint8List(2),
+        ats: Uint8List(0),
+      );
+
+  @override
+  Future<Uint8List> send14ARaw(
+    Uint8List data, {
+    int respTimeoutMs = 100,
+    int? bitLen,
+    bool activateRfField = true,
+    bool waitResponse = true,
+    bool appendCrc = true,
+    bool autoSelect = true,
+    bool keepRfField = false,
+    bool checkResponseCrc = true,
+  }) async {
+    rawCommands.add(data.toList());
+    afterRawCommand();
+    return Uint8List(0);
+  }
+}
+
+class _PreflightCommunicator extends ChameleonCommunicator {
+  _PreflightCommunicator(
+    super.log, {
+    this.supportsClassic = false,
+    this.afterSupportCheck,
+    this.afterScan,
+  });
+
+  final bool supportsClassic;
+  final void Function()? afterSupportCheck;
+  final void Function()? afterScan;
+  int supportChecks = 0;
+  int scans = 0;
+  final List<List<int>> rawCommands = [];
+
+  @override
+  Future<bool> isReaderDeviceMode() async => true;
+
+  @override
+  Future<bool> detectMf1Support() async {
+    supportChecks++;
+    afterSupportCheck?.call();
+    return supportsClassic;
+  }
+
+  @override
+  Future<CardData?> scan14443aTag() async {
+    scans++;
+    afterScan?.call();
+    return CardData(
+      uid: Uint8List.fromList([1, 2, 3, 4]),
+      sak: 0x08,
+      atqa: Uint8List.fromList([0x00, 0x04]),
+      ats: Uint8List(0),
+    );
+  }
+
+  @override
+  Future<Uint8List> send14ARaw(
+    Uint8List data, {
+    int respTimeoutMs = 100,
+    int? bitLen,
+    bool activateRfField = true,
+    bool waitResponse = true,
+    bool appendCrc = true,
+    bool autoSelect = true,
+    bool keepRfField = false,
+    bool checkResponseCrc = true,
+  }) async {
+    rawCommands.add(data.toList());
+    if (data.length == 1 && data[0] == 0) {
+      return Uint8List(0);
+    }
+    if (data.first == 0x40 || data.first == 0x43) {
+      return Uint8List.fromList([0x0A]);
+    }
+    return Uint8List(0);
   }
 }
 


### PR DESCRIPTION
# RF session ownership and destructive-write safety

## Summary

- Add one application-owned RF operation coordinator with FIFO foreground access and non-blocking background acquisition.
- Bind queued foreground work to the connector and communicator that were current when the operation was requested.
- Stop MIFARE Classic Gen1, Gen2, and Gen3 write workflows when an issued destructive command has an unknown outcome.
- Apply the same session and unknown-outcome rules to the existing Ultralight and T55xx writers, T55xx password cleaner, and helper read-back.
- Route Magic-card selection/detection/compatibility, Slot Manager and slot dialogs, Home status reads and reader-mode switching, and HF/LF sniff capture through the same foreground FIFO.

## RF ownership contract

`ChameleonGUIState` owns one `RfOperationCoordinator`. `runSessionBoundForeground` captures the connected, non-DFU device session before enqueueing and validates it again after the FIFO lease is acquired. Multi-command callbacks receive that session and can stop before every follow-up command when the connector, communicator, connection state, or DFU state changes.

The result type distinguishes three cases that were previously conflated:

- the operation was rejected before its callback ran;
- the callback ran and returned a value, including an intentional `null`;
- the callback ran and failed, with the captured session and stack trace retained when the catching variant is used.

Foreground failures always release the lease. Background operations skip instead of queueing when foreground work is active or waiting, so they cannot starve the FIFO.

## Destructive-write invariant

After a write command has been issued, a timeout, transport error, missing acknowledgement, stale session, or failed verification is treated as an unknown outcome. The workflow stops immediately. It does not try another key, block, trailer, or sector.

An explicit protocol rejection remains retryable where the existing workflow already allowed it. Gen3 resets its per-operation outcome state before a later full write.

T55xx keeps the required safety read-back after a completed write. A missing or failed read-back stops password iteration because the previous write may have reached the tag.

## Tests

- Coordinator tests cover background skipping, FIFO order, foreground priority, and lease release after exceptions.
- Session tests cover success, nullable success, no connection, connector replacement, reconnect, DFU transition, and callback exceptions.
- Public write tests cover ambiguous and explicitly rejected Gen1/Gen2/Gen3 writes, full Gen2 trailer and Gen3 block-zero workflows, later Gen3 reuse, stale-session read-back, and T55xx helper/password-cleaner failure paths.
- Write Card widget tests cover queued card probing, stale Magic auto-detection, queued compatibility checks, between-command invalidation, and Ultralight handling of stale sessions and missing, invalid, or valid write acknowledgements.
- Home widget tests cover FIFO-blocked status initialization and coherent re-reading after communicator replacement without publishing mixed-session data.
- Foreground-workflow widget tests cover Slot Manager upload ordering and invalidation, Slot Changer metadata ordering, and stale LF capture; the full suite also exercises the migrated slot-dialog and HF/LF sniff surfaces.
- Full Flutter test suite passes with the locally built macOS recovery framework.
- macOS debug build passes with Xcode 26.3 selected through `DEVELOPER_DIR`.
- `flutter analyze` reports only the existing deprecated `FontVariation.index` use in `lib/helpers/font.dart`, which is outside this diff.

## Deliberate exclusions

- MIFARE Classic key profiles, saved dumps, imports, exports, and maintenance UI.
- Standard normal-card writer.
- Persistent or offstage Read Card behavior, continuous scans, and Read Card UI lifecycle changes.
- Localization source or generated locale files.
- Dependency locks and generated macOS project upgrades.

This branch is based directly on current `origin/main`; it does not replay the feature branch history.
