### PR TITLE
fix: star history chart is broken, switch to a working provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ Crypto Currencies if your into that jam (Although open collective is preferred):
 
 ## Star History
 
-<a href="https://star-history.com/#GameTec-live/ChameleonUltraGUI&Timeline">
+<a href="https://star-history.dera.page/#GameTec-live/ChameleonUltraGUI&type=date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=GameTec-live/ChameleonUltraGUI&type=Timeline&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=GameTec-live/ChameleonUltraGUI&type=Timeline" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=GameTec-live/ChameleonUltraGUI&type=Timeline" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=GameTec-live/ChameleonUltraGUI&type=Timeline&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=GameTec-live/ChameleonUltraGUI&type=Timeline" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=GameTec-live/ChameleonUltraGUI&type=Timeline" />
   </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is broken because of GitHub stargazer API restrictions, so the graph no longer renders. This PR points the chart at an alternative provider that keeps the graph working without requiring an API token. Only the star history chart is affected; the rest of the README is unchanged.