### PR TITLE
fix(mifare): handle readable Key B fields correctly

### DIFF
--- a/chameleonultragui/lib/gui/component/key_check_marks.dart
+++ b/chameleonultragui/lib/gui/component/key_check_marks.dart
@@ -48,6 +48,7 @@ class _KeyCheckMarksState extends State<KeyCheckMarks> {
         _dragValue = ChameleonKeyCheckmark.none;
         break;
       case ChameleonKeyCheckmark.found:
+      case ChameleonKeyCheckmark.readable:
       case ChameleonKeyCheckmark.checking:
         _dragValue = null;
         break;
@@ -120,6 +121,15 @@ class _KeyCheckMarksState extends State<KeyCheckMarks> {
           child: const Icon(
             Icons.check,
             color: Colors.green,
+          ),
+        );
+      case ChameleonKeyCheckmark.readable:
+        return Tooltip(
+          message: "${localizations.key} B: ${localizations.read}",
+          preferBelow: tooltipBelow,
+          child: const Icon(
+            Icons.visibility,
+            color: Colors.blue,
           ),
         );
       case ChameleonKeyCheckmark.none:

--- a/chameleonultragui/lib/gui/component/key_check_marks.dart
+++ b/chameleonultragui/lib/gui/component/key_check_marks.dart
@@ -10,6 +10,7 @@ class KeyCheckMarks extends StatefulWidget {
   final int checkmarkCount;
   final List<ChameleonKeyCheckmark> checkMarks;
   final List<Uint8List> validKeys;
+  final List<Uint8List> readableData;
   final int checkmarkPerRow;
   final double checkmarkSize;
   final double fontSize;
@@ -20,6 +21,7 @@ class KeyCheckMarks extends StatefulWidget {
       {super.key,
       required this.checkMarks,
       required this.validKeys,
+      required this.readableData,
       this.checkmarkCount = 16,
       this.checkmarkPerRow = 16,
       this.checkmarkSize = 20,
@@ -125,7 +127,8 @@ class _KeyCheckMarksState extends State<KeyCheckMarks> {
         );
       case ChameleonKeyCheckmark.readable:
         return Tooltip(
-          message: "${localizations.key} B: ${localizations.read}",
+          message:
+              "Data: ${bytesToHex(widget.readableData[index]).toUpperCase()}",
           preferBelow: tooltipBelow,
           child: const Icon(
             Icons.visibility,

--- a/chameleonultragui/lib/gui/component/mifare/classic.dart
+++ b/chameleonultragui/lib/gui/component/mifare/classic.dart
@@ -125,6 +125,7 @@ class CardReaderState extends State<MifareClassicHelper> {
             KeyCheckMarks(
                 checkMarks: widget.mfcInfo.recovery!.checkMarks,
                 validKeys: widget.mfcInfo.recovery!.validKeys,
+                readableData: widget.mfcInfo.recovery!.readableData,
                 fontSize: checkmarkFontSize,
                 checkmarkSize: checkmarkSize,
                 checkmarkCount: mfClassicGetSectorCount(widget.mfcInfo.type,

--- a/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
@@ -37,6 +37,7 @@ class MifareClassicRecovery {
   Dictionary? selectedDictionary;
   List<ChameleonKeyCheckmark> checkMarks;
   List<Uint8List> validKeys;
+  List<Uint8List> readableData;
   List<Uint8List> cardData;
   double dumpProgress;
   double? hardnestedProgress;
@@ -59,10 +60,13 @@ class MifareClassicRecovery {
       this.isMifareClassicEV1 = false,
       List<ChameleonKeyCheckmark>? checkMarks,
       List<Uint8List>? validKeys,
+      List<Uint8List>? readableData,
       List<Uint8List>? cardData})
       : checkMarks =
             checkMarks ?? List.generate(80, (_) => ChameleonKeyCheckmark.none),
         validKeys = validKeys ?? List.generate(80, (_) => Uint8List(0)),
+        readableData =
+            readableData ?? List.generate(80, (_) => Uint8List(0)),
         cardData = cardData ?? List.generate(256, (_) => Uint8List(0)) {
     initializeEV1();
   }
@@ -121,6 +125,7 @@ class MifareClassicRecovery {
     if (await _canUseKeyBForMemoryAccess(sector, keyB)) {
       setKeyAsFound(sector, 1, keyB);
     } else {
+      readableData[sector + 40] = keyB;
       checkMarks[sector + 40] = ChameleonKeyCheckmark.readable;
       update();
     }
@@ -751,6 +756,7 @@ class MifareClassicRecovery {
   void setKeyAsFound(int sector, int keyType, Uint8List key) {
     checkMarks[sector + (keyType * 40)] = ChameleonKeyCheckmark.found;
     validKeys[sector + (keyType * 40)] = key;
+    readableData[sector + (keyType * 40)] = Uint8List(0);
     update();
   }
 

--- a/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
@@ -74,8 +74,12 @@ class MifareClassicRecovery {
         checkMark == ChameleonKeyCheckmark.disabled;
   }
 
-  bool _permissionAllowsKeyB(int permission) {
-    return permission == 2 || permission == 3;
+  Future<bool> _canUseKeyBForMemoryAccess(
+      int sector, Uint8List keyB) async {
+    final trailerBlock = mfClassicGetSectorTrailerBlockBySector(sector);
+    final block =
+        await appState.communicator!.mf1ReadBlock(trailerBlock, 0x61, keyB);
+    return block.length == 16;
   }
 
   Future<void> _resolveReadableKeyB(int sector, Uint8List keyA) async {
@@ -110,39 +114,11 @@ class MifareClassicRecovery {
     }
 
     final keyB = Uint8List.fromList(block.sublist(10, 16));
-    bool keyBReadSucceeded = false;
 
     // A readable Key B is normally data rather than an authentication key.
     // Some compatible cards nevertheless accept those same bytes as Key B.
-    // Verify that behavior with a non-destructive memory read before deciding
-    // whether to store the bytes as an authentication key.
-    for (var dataBlock = 0; dataBlock < 3; dataBlock++) {
-      final dataPermissions = MifareClassicDumpAnalyzer.dataAccessPermissions(
-          accessConditions[dataBlock]);
-      if (!_permissionAllowsKeyB(dataPermissions[0])) {
-        continue;
-      }
-
-      final testBlock =
-          mfClassicGetFirstBlockCountBySector(sector) + dataBlock;
-      final testData =
-          await appState.communicator!.mf1ReadBlock(testBlock, 0x61, keyB);
-      if (testData.length == 16) {
-        keyBReadSucceeded = true;
-        break;
-      }
-    }
-
-    // If no data block offers a safe Key-B read, the trailer itself can be
-    // used when its access bits are readable with Key B.
-    if (!keyBReadSucceeded &&
-        _permissionAllowsKeyB(trailerPermissions[1][0])) {
-      final testData =
-          await appState.communicator!.mf1ReadBlock(trailerBlock, 0x61, keyB);
-      keyBReadSucceeded = testData.length == 16;
-    }
-
-    if (keyBReadSucceeded) {
+    // Verify an actual memory operation before storing it as a valid key.
+    if (await _canUseKeyBForMemoryAccess(sector, keyB)) {
       setKeyAsFound(sector, 1, keyB);
     } else {
       checkMarks[sector + 40] = ChameleonKeyCheckmark.readable;
@@ -153,7 +129,6 @@ class MifareClassicRecovery {
   Future<bool> checkKeysOnSector(
       List<Uint8List> keys, int keyType, int sector) async {
     state = localizations.checking_keys(keys.length);
-    Uint8List? key;
     keyCheckProgress = null;
     int chunkSize =
         appState.connector!.connectionType == ConnectionType.ble ? 32 : 64;
@@ -166,12 +141,26 @@ class MifareClassicRecovery {
     int totalChunks = keys.partition(chunkSize).length;
 
     for (var chunk in keys.partition(chunkSize)) {
-      key = await appState.communicator!.mf1AuthMultipleKeys(
-          mfClassicGetSectorTrailerBlockBySector(sector),
-          0x60 + keyType,
-          chunk);
+      final remainingKeys = List<Uint8List>.from(chunk);
 
-      if (key != null) {
+      while (remainingKeys.isNotEmpty) {
+        final key = await appState.communicator!.mf1AuthMultipleKeys(
+            mfClassicGetSectorTrailerBlockBySector(sector),
+            0x60 + keyType,
+            remainingKeys);
+
+        if (key == null) {
+          break;
+        }
+
+        if (keyType == 1 &&
+            !await _canUseKeyBForMemoryAccess(sector, key)) {
+          final rejectedKey = bytesToHex(key);
+          remainingKeys
+              .removeWhere((candidate) => bytesToHex(candidate) == rejectedKey);
+          continue;
+        }
+
         setKeyAsFound(sector, keyType, key);
 
         if (keyType == 0) {
@@ -181,7 +170,9 @@ class MifareClassicRecovery {
         keyCheckProgress = null;
         await recheckKey(key, sector);
         return true;
-      } else if (totalChunks > 10) {
+      }
+
+      if (totalChunks > 10) {
         keyCheckProgress = (keyCheckProgress ?? 0) + 1 / totalChunks;
         update();
       }
@@ -223,11 +214,14 @@ class MifareClassicRecovery {
               "Checking found key ${bytesToHex(key)} on sector $sector, key type $keyType");
           setCheckingSector(sector, keyType);
 
-          if (await appState.communicator!.mf1Auth(
+          final authenticated = await appState.communicator!.mf1Auth(
               mfClassicGetSectorTrailerBlockBySector(sector),
               0x60 + keyType,
-              key)) {
-            // Found valid key
+              key);
+
+          if (authenticated &&
+              (keyType == 0 ||
+                  await _canUseKeyBForMemoryAccess(sector, key))) {
             setKeyAsFound(sector, keyType, key);
             if (keyType == 0) {
               await _resolveReadableKeyB(sector, key);

--- a/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
@@ -74,13 +74,18 @@ class MifareClassicRecovery {
         checkMark == ChameleonKeyCheckmark.disabled;
   }
 
-  Future<void> _markReadableKeyB(int sector, Uint8List keyA) async {
+  bool _permissionAllowsKeyB(int permission) {
+    return permission == 2 || permission == 3;
+  }
+
+  Future<void> _resolveReadableKeyB(int sector, Uint8List keyA) async {
     if (_isResolvedKeyState(sector, 1)) {
       return;
     }
 
-    final block = await appState.communicator!.mf1ReadBlock(
-        mfClassicGetSectorTrailerBlockBySector(sector), 0x60, keyA);
+    final trailerBlock = mfClassicGetSectorTrailerBlockBySector(sector);
+    final block =
+        await appState.communicator!.mf1ReadBlock(trailerBlock, 0x60, keyA);
 
     if (block.length != 16) {
       return;
@@ -93,10 +98,53 @@ class MifareClassicRecovery {
       return;
     }
 
-    final keyBPermissions = MifareClassicDumpAnalyzer.trailerAccessPermissions(
-        accessConditions[3])[2];
+    final trailerPermissions =
+        MifareClassicDumpAnalyzer.trailerAccessPermissions(
+            accessConditions[3]);
+    final keyBReadPermission = trailerPermissions[2][0];
 
-    if (keyBPermissions[0] == 1 || keyBPermissions[0] == 3) {
+    // Key B is only available in the card-returned trailer bytes when Key A
+    // is permitted to read that field.
+    if (keyBReadPermission != 1 && keyBReadPermission != 3) {
+      return;
+    }
+
+    final keyB = Uint8List.fromList(block.sublist(10, 16));
+    bool keyBReadSucceeded = false;
+
+    // A readable Key B is normally data rather than an authentication key.
+    // Some compatible cards nevertheless accept those same bytes as Key B.
+    // Verify that behavior with a non-destructive memory read before deciding
+    // whether to store the bytes as an authentication key.
+    for (var dataBlock = 0; dataBlock < 3; dataBlock++) {
+      final dataPermissions = MifareClassicDumpAnalyzer.dataAccessPermissions(
+          accessConditions[dataBlock]);
+      if (!_permissionAllowsKeyB(dataPermissions[0])) {
+        continue;
+      }
+
+      final testBlock =
+          mfClassicGetFirstBlockCountBySector(sector) + dataBlock;
+      final testData =
+          await appState.communicator!.mf1ReadBlock(testBlock, 0x61, keyB);
+      if (testData.length == 16) {
+        keyBReadSucceeded = true;
+        break;
+      }
+    }
+
+    // If no data block offers a safe Key-B read, the trailer itself can be
+    // used when its access bits are readable with Key B.
+    if (!keyBReadSucceeded &&
+        _permissionAllowsKeyB(trailerPermissions[1][0])) {
+      final testData =
+          await appState.communicator!.mf1ReadBlock(trailerBlock, 0x61, keyB);
+      keyBReadSucceeded = testData.length == 16;
+    }
+
+    if (keyBReadSucceeded) {
+      setKeyAsFound(sector, 1, keyB);
+    } else {
       checkMarks[sector + 40] = ChameleonKeyCheckmark.readable;
       update();
     }
@@ -127,7 +175,7 @@ class MifareClassicRecovery {
         setKeyAsFound(sector, keyType, key);
 
         if (keyType == 0) {
-          await _markReadableKeyB(sector, key);
+          await _resolveReadableKeyB(sector, key);
         }
 
         keyCheckProgress = null;
@@ -182,7 +230,7 @@ class MifareClassicRecovery {
             // Found valid key
             setKeyAsFound(sector, keyType, key);
             if (keyType == 0) {
-              await _markReadableKeyB(sector, key);
+              await _resolveReadableKeyB(sector, key);
             }
           } else {
             setMissingSector(sector, keyType);

--- a/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
@@ -4,6 +4,7 @@ import 'package:chameleonultragui/connector/serial_abstract.dart';
 import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
 import 'package:chameleonultragui/helpers/definitions.dart';
 import 'package:chameleonultragui/helpers/general.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/dump_analyzer.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/general.dart';
 import 'package:chameleonultragui/main.dart';
 import 'package:chameleonultragui/recovery/recovery.dart';
@@ -24,7 +25,7 @@ extension PartitionList<E> on List<E> {
   }
 }
 
-enum ChameleonKeyCheckmark { none, found, checking, disabled }
+enum ChameleonKeyCheckmark { none, found, readable, checking, disabled }
 
 class MifareClassicRecovery {
   late ChameleonGUIState appState;
@@ -66,6 +67,41 @@ class MifareClassicRecovery {
     initializeEV1();
   }
 
+  bool _isResolvedKeyState(int sector, int keyType) {
+    final checkMark = getSectorState(sector, keyType);
+    return checkMark == ChameleonKeyCheckmark.found ||
+        checkMark == ChameleonKeyCheckmark.readable ||
+        checkMark == ChameleonKeyCheckmark.disabled;
+  }
+
+  Future<void> _markReadableKeyB(int sector, Uint8List keyA) async {
+    if (_isResolvedKeyState(sector, 1)) {
+      return;
+    }
+
+    final block = await appState.communicator!.mf1ReadBlock(
+        mfClassicGetSectorTrailerBlockBySector(sector), 0x60, keyA);
+
+    if (block.length != 16) {
+      return;
+    }
+
+    final accessConditions = MifareClassicDumpAnalyzer.accessConditionValues(
+        bytesToHex(block.sublist(6, 9)));
+
+    if (accessConditions == null) {
+      return;
+    }
+
+    final keyBPermissions = MifareClassicDumpAnalyzer.trailerAccessPermissions(
+        accessConditions[3])[2];
+
+    if (keyBPermissions[0] == 1 || keyBPermissions[0] == 3) {
+      checkMarks[sector + 40] = ChameleonKeyCheckmark.readable;
+      update();
+    }
+  }
+
   Future<bool> checkKeysOnSector(
       List<Uint8List> keys, int keyType, int sector) async {
     state = localizations.checking_keys(keys.length);
@@ -74,46 +110,32 @@ class MifareClassicRecovery {
     int chunkSize =
         appState.connector!.connectionType == ConnectionType.ble ? 32 : 64;
 
-    if (getSectorState(sector, keyType) != ChameleonKeyCheckmark.found &&
-        getSectorState(sector, keyType) != ChameleonKeyCheckmark.disabled) {
-      setCheckingSector(sector, keyType);
-      int totalChunks = keys.partition(chunkSize).length;
-
-      for (var chunk in keys.partition(chunkSize)) {
-        key = await appState.communicator!.mf1AuthMultipleKeys(
-            mfClassicGetSectorTrailerBlockBySector(sector),
-            0x60 + keyType,
-            chunk);
-        if (key != null) {
-          setKeyAsFound(sector, keyType, key);
-          keyCheckProgress = null;
-          await recheckKey(key, sector);
-          return true;
-        } else if (totalChunks > 10) {
-          keyCheckProgress = (keyCheckProgress ?? 0) + 1 / totalChunks;
-          update();
-        }
-      }
-
-      if (key == null) {
-        setMissingSector(sector, keyType);
-      }
+    if (_isResolvedKeyState(sector, keyType)) {
+      return getSectorState(sector, keyType) != ChameleonKeyCheckmark.disabled;
     }
 
-    if (keyType == 0 &&
-        getSectorState(sector, 0) == ChameleonKeyCheckmark.found &&
-        getSectorState(sector, 1) != ChameleonKeyCheckmark.found &&
-        getSectorState(sector, 1) != ChameleonKeyCheckmark.disabled &&
-        key != null) {
-      Uint8List block = await appState.communicator!.mf1ReadBlock(
-          mfClassicGetSectorTrailerBlockBySector(sector), 0x60 + keyType, key);
-      if (block.length == 16) {
-        Uint8List bKey = block.sublist(10);
-        if (bytesToHex(bKey) != bytesToHex(Uint8List(6))) {
-          keyCheckProgress = null;
-          await recheckKey(key, sector);
-          return true;
+    setCheckingSector(sector, keyType);
+    int totalChunks = keys.partition(chunkSize).length;
+
+    for (var chunk in keys.partition(chunkSize)) {
+      key = await appState.communicator!.mf1AuthMultipleKeys(
+          mfClassicGetSectorTrailerBlockBySector(sector),
+          0x60 + keyType,
+          chunk);
+
+      if (key != null) {
+        setKeyAsFound(sector, keyType, key);
+
+        if (keyType == 0) {
+          await _markReadableKeyB(sector, key);
         }
+
+        keyCheckProgress = null;
+        await recheckKey(key, sector);
+        return true;
+      } else if (totalChunks > 10) {
+        keyCheckProgress = (keyCheckProgress ?? 0) + 1 / totalChunks;
+        update();
       }
     }
 
@@ -159,6 +181,9 @@ class MifareClassicRecovery {
               key)) {
             // Found valid key
             setKeyAsFound(sector, keyType, key);
+            if (keyType == 0) {
+              await _markReadableKeyB(sector, key);
+            }
           } else {
             setMissingSector(sector, keyType);
           }
@@ -206,8 +231,7 @@ class MifareClassicRecovery {
                 isEV1: isMifareClassicEV1);
         sector++) {
       for (var keyType = 0; keyType < 2; keyType++) {
-        if (getSectorState(sector, keyType) != ChameleonKeyCheckmark.found &&
-            getSectorState(sector, keyType) != ChameleonKeyCheckmark.disabled) {
+        if (!_isResolvedKeyState(sector, keyType)) {
           allKeysExists = false;
         }
       }
@@ -497,8 +521,7 @@ class MifareClassicRecovery {
                   backdoorInfo.$2.nonces[sector].nt,
                   backdoorInfo.$3.nonces[sector].nt);
 
-              if (checkMarks[sector + 40] != ChameleonKeyCheckmark.found &&
-                  checkMarks[sector + 40] != ChameleonKeyCheckmark.disabled &&
+              if (!_isResolvedKeyState(sector, 1) &&
                   await checkKeysOnSector(
                       mfClassicConvertKeys(filtered.$2.reversed.toList()),
                       1,
@@ -559,8 +582,7 @@ class MifareClassicRecovery {
                 isEV1: isMifareClassicEV1);
         sector++) {
       for (var keyType = 0; keyType < 2; keyType++) {
-        if (getSectorState(sector, keyType) != ChameleonKeyCheckmark.found &&
-            getSectorState(sector, keyType) != ChameleonKeyCheckmark.disabled) {
+        if (!_isResolvedKeyState(sector, keyType)) {
           allKeysExists = false;
         }
       }

--- a/chameleonultragui/test/key_check_marks_test.dart
+++ b/chameleonultragui/test/key_check_marks_test.dart
@@ -13,6 +13,8 @@ void main() {
     final checkMarks =
         List.filled(80, ChameleonKeyCheckmark.none, growable: false);
     final validKeys = List.generate(80, (_) => Uint8List(0), growable: false);
+    final readableData =
+        List.generate(80, (_) => Uint8List(0), growable: false);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -24,6 +26,7 @@ void main() {
               return KeyCheckMarks(
                 checkMarks: checkMarks,
                 validKeys: validKeys,
+                readableData: readableData,
                 checkmarkCount: 3,
                 checkmarkPerRow: 3,
                 onCheckmarkChanged: (index, newValue) {


### PR DESCRIPTION
~~## Summary~~

~~Fix MIFARE Classic recovery handling for sector trailers where Key B is configured as readable data.~~

~~Previously, these Key B fields could remain displayed as failed/unresolved keys even though the sector trailer was successfully readable with Key A.~~

~~This change:~~

~~- adds a distinct `readable` state for Key B~~
~~- checks the sector trailer access conditions after finding Key A~~
~~- marks readable Key B fields as resolved without treating them as authentication keys~~
~~- displays readable Key B fields with a separate visibility icon~~
~~- keeps readable Key B data out of `validKeys`~~
~~- allows the card-returned Key B bytes to remain intact in dumps~~
~~- prevents readable Key B data from being exported as recovered authentication keys~~

~~## Testing~~

~~Tested against a physical MIFARE Classic 1K card with readable Key B fields.~~

~~Verified:~~

~~- readable Key B fields are displayed distinctly instead of as failed keys~~
~~- recovered Key A authentication keys remain displayed normally~~
~~- card-returned Key B field bytes are preserved in the resulting dump~~
~~- readable Key B data is not exported by "Export found keys"~~
~~- `flutter analyze --no-pub` reports no issues related to this change~~
~~  - one unrelated existing deprecation remains in `lib/helpers/font.dart`~~
~~- `flutter test --no-pub`: 18 tests passed~~
~~- Windows release build completed successfully~~