### PR TITLE
Fix readable MIFARE Classic Key B handling

### DIFF
--- a/chameleonultragui/lib/gui/component/key_check_marks.dart
+++ b/chameleonultragui/lib/gui/component/key_check_marks.dart
@@ -48,6 +48,7 @@ class _KeyCheckMarksState extends State<KeyCheckMarks> {
         _dragValue = ChameleonKeyCheckmark.none;
         break;
       case ChameleonKeyCheckmark.found:
+      case ChameleonKeyCheckmark.readable:
       case ChameleonKeyCheckmark.checking:
         _dragValue = null;
         break;
@@ -120,6 +121,15 @@ class _KeyCheckMarksState extends State<KeyCheckMarks> {
           child: const Icon(
             Icons.check,
             color: Colors.green,
+          ),
+        );
+      case ChameleonKeyCheckmark.readable:
+        return Tooltip(
+          message: "${localizations.key} B: ${localizations.read}",
+          preferBelow: tooltipBelow,
+          child: const Icon(
+            Icons.visibility,
+            color: Colors.blue,
           ),
         );
       case ChameleonKeyCheckmark.none:

--- a/chameleonultragui/lib/gui/component/key_check_marks.dart
+++ b/chameleonultragui/lib/gui/component/key_check_marks.dart
@@ -127,8 +127,7 @@ class _KeyCheckMarksState extends State<KeyCheckMarks> {
         );
       case ChameleonKeyCheckmark.readable:
         return Tooltip(
-          message:
-              "Data: ${bytesToHex(widget.readableData[index]).toUpperCase()}",
+          message: bytesToHex(widget.readableData[index]).toUpperCase(),
           preferBelow: tooltipBelow,
           child: const Icon(
             Icons.visibility,

--- a/chameleonultragui/lib/gui/component/key_check_marks.dart
+++ b/chameleonultragui/lib/gui/component/key_check_marks.dart
@@ -10,6 +10,7 @@ class KeyCheckMarks extends StatefulWidget {
   final int checkmarkCount;
   final List<ChameleonKeyCheckmark> checkMarks;
   final List<Uint8List> validKeys;
+  final List<Uint8List> readableData;
   final int checkmarkPerRow;
   final double checkmarkSize;
   final double fontSize;
@@ -20,6 +21,7 @@ class KeyCheckMarks extends StatefulWidget {
       {super.key,
       required this.checkMarks,
       required this.validKeys,
+      required this.readableData,
       this.checkmarkCount = 16,
       this.checkmarkPerRow = 16,
       this.checkmarkSize = 20,
@@ -125,7 +127,8 @@ class _KeyCheckMarksState extends State<KeyCheckMarks> {
         );
       case ChameleonKeyCheckmark.readable:
         return Tooltip(
-          message: "${localizations.key} B: ${localizations.read}",
+          message:
+              "Data: ${bytesToHex(widget.readableData[index]).toUpperCase()}",
           preferBelow: tooltipBelow,
           child: const Icon(
             Icons.visibility,

--- a/chameleonultragui/lib/gui/component/mifare/classic.dart
+++ b/chameleonultragui/lib/gui/component/mifare/classic.dart
@@ -125,6 +125,7 @@ class CardReaderState extends State<MifareClassicHelper> {
             KeyCheckMarks(
                 checkMarks: widget.mfcInfo.recovery!.checkMarks,
                 validKeys: widget.mfcInfo.recovery!.validKeys,
+                readableData: widget.mfcInfo.recovery!.readableData,
                 fontSize: checkmarkFontSize,
                 checkmarkSize: checkmarkSize,
                 checkmarkCount: mfClassicGetSectorCount(widget.mfcInfo.type,

--- a/chameleonultragui/lib/gui/component/mifare/classic.dart
+++ b/chameleonultragui/lib/gui/component/mifare/classic.dart
@@ -147,7 +147,7 @@ class CardReaderState extends State<MifareClassicHelper> {
           const SizedBox(height: 8),
           Text(widget.mfcInfo.recovery!.state.isNotEmpty
               ? widget.mfcInfo.recovery!.state
-              : "Success"),
+              : "Recovery Completed Successfully"),
         ],
         const SizedBox(height: 12),
         if (widget.mfcInfo.recovery?.dumpProgress != 0) ...[

--- a/chameleonultragui/lib/gui/component/mifare/classic.dart
+++ b/chameleonultragui/lib/gui/component/mifare/classic.dart
@@ -142,9 +142,12 @@ class CardReaderState extends State<MifareClassicHelper> {
           const SizedBox(height: 16),
           ErrorMessage(errorMessage: widget.mfcInfo.recovery!.error),
         ],
-        if (widget.mfcInfo.recovery?.state != "") ...[
+        if (widget.mfcInfo.recovery?.state != "" ||
+            (!widget.allowSave && widget.mfcInfo.recovery!.allKeysExists)) ...[
           const SizedBox(height: 8),
-          Text(widget.mfcInfo.recovery!.state),
+          Text(widget.mfcInfo.recovery!.state.isNotEmpty
+              ? widget.mfcInfo.recovery!.state
+              : "Success"),
         ],
         const SizedBox(height: 12),
         if (widget.mfcInfo.recovery?.dumpProgress != 0) ...[

--- a/chameleonultragui/lib/gui/page/write_card.dart
+++ b/chameleonultragui/lib/gui/page/write_card.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:chameleonultragui/connector/serial_abstract.dart';
 import 'package:chameleonultragui/gui/component/card_list.dart';
 import 'package:chameleonultragui/helpers/definitions.dart';
@@ -25,6 +27,8 @@ class WriteCardPageState extends State<WriteCardPage> {
   CardSave? card;
   AbstractWriteHelper? baseHelper;
   AbstractWriteHelper? helper;
+  Timer? _writeReadyTimer;
+  bool _writeReadyDelayComplete = false;
 
   Future<String?> cardSelectDialog(BuildContext context) {
     var appState = context.read<ChameleonGUIState>();
@@ -41,6 +45,8 @@ class WriteCardPageState extends State<WriteCardPage> {
   Future<void> onTap(CardSave selectedCard, dynamic close,
       AppLocalizations localizations) async {
     var appState = Provider.of<ChameleonGUIState>(context, listen: false);
+
+    _resetWriteReadyDelay();
 
     setState(() {
       card = selectedCard;
@@ -71,6 +77,8 @@ class WriteCardPageState extends State<WriteCardPage> {
 
     for (final magicHelper in baseHelper!.getAvailableMethods()) {
       if (await magicHelper.isMagic(card)) {
+        _resetWriteReadyDelay();
+
         setState(() {
           helper = magicHelper;
         });
@@ -112,12 +120,59 @@ class WriteCardPageState extends State<WriteCardPage> {
     setState(() {
       helper = helper;
     });
+    _syncWriteReadyDelay();
   }
 
   void updateProgress(int writeProgress) {
     setState(() {
       progress = writeProgress;
     });
+  }
+
+  bool _usesWriteReadyDelay() =>
+      helper?.name == 'gen2' || helper?.name == 'gen3';
+
+  bool _isReadyForWriteUi() {
+    final ready = helper?.isReady() ?? false;
+
+    if (!_usesWriteReadyDelay()) {
+      return ready;
+    }
+
+    return ready && _writeReadyDelayComplete;
+  }
+
+  void _resetWriteReadyDelay() {
+    _writeReadyTimer?.cancel();
+    _writeReadyTimer = null;
+    _writeReadyDelayComplete = false;
+  }
+
+  void _syncWriteReadyDelay() {
+    if (!_usesWriteReadyDelay() || !(helper?.isReady() ?? false)) {
+      _resetWriteReadyDelay();
+      return;
+    }
+
+    if (_writeReadyDelayComplete || _writeReadyTimer != null) {
+      return;
+    }
+
+    _writeReadyTimer = Timer(const Duration(seconds: 2), () {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _writeReadyDelayComplete = true;
+        _writeReadyTimer = null;
+      });
+    });
+  }
+
+  void _writeWidgetSetState(VoidCallback callback) {
+    setState(callback);
+    _syncWriteReadyDelay();
   }
 
   Future<void> writeCard() async {
@@ -190,7 +245,7 @@ class WriteCardPageState extends State<WriteCardPage> {
       setState(() {
         step++;
       });
-    } else if (helper != null && helper!.isReady() && progress == -1) {
+    } else if (_isReadyForWriteUi() && progress == -1) {
       SnackBar snackBar;
       updateProgress(0);
 
@@ -216,6 +271,8 @@ class WriteCardPageState extends State<WriteCardPage> {
   }
 
   void onStepBack() async {
+    _resetWriteReadyDelay();
+
     setState(() {
       written = false;
       step--;
@@ -227,6 +284,8 @@ class WriteCardPageState extends State<WriteCardPage> {
   }
 
   void onStepReset() async {
+    _resetWriteReadyDelay();
+
     setState(() {
       written = false;
       step = 0;
@@ -260,9 +319,8 @@ class WriteCardPageState extends State<WriteCardPage> {
 
       if (step == 2) {
         widgets.add(TextButton(
-          onPressed: (helper != null && helper!.isReady() && progress == -1)
-              ? onStepContinue
-              : null,
+          onPressed:
+              (_isReadyForWriteUi() && progress == -1) ? onStepContinue : null,
           child: Text(localizations.write_data_to_magic_card),
         ));
       }
@@ -281,6 +339,12 @@ class WriteCardPageState extends State<WriteCardPage> {
   @override
   void initState() {
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    _writeReadyTimer?.cancel();
+    super.dispose();
   }
 
   @override
@@ -362,6 +426,8 @@ class WriteCardPageState extends State<WriteCardPage> {
                                 );
                               }).toList(),
                               onChanged: (AbstractWriteHelper? helperClass) {
+                                _resetWriteReadyDelay();
+
                                 setState(() {
                                   helper = helperClass;
                                 });
@@ -387,7 +453,7 @@ class WriteCardPageState extends State<WriteCardPage> {
             content: Card(
               child: ListTile(
                 title: (progress == -1)
-                    ? (helper != null && helper!.isReady())
+                    ? _isReadyForWriteUi()
                         ? (helper != null &&
                                 helper!.getFailedBlocks().isNotEmpty)
                             ? Text(
@@ -402,7 +468,8 @@ class WriteCardPageState extends State<WriteCardPage> {
                                         fontWeight: FontWeight.bold))
                               ])
                         : (helper != null && helper!.writeWidgetSupported())
-                            ? helper!.getWriteWidget(context, setState)
+                            ? helper!
+                                .getWriteWidget(context, _writeWidgetSetState)
                             : Text(localizations.error)
                     : LinearProgressIndicator(value: progress.toDouble() / 100),
               ),

--- a/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
@@ -37,6 +37,7 @@ class MifareClassicRecovery {
   Dictionary? selectedDictionary;
   List<ChameleonKeyCheckmark> checkMarks;
   List<Uint8List> validKeys;
+  List<Uint8List> readableData;
   List<Uint8List> cardData;
   double dumpProgress;
   double? hardnestedProgress;
@@ -59,10 +60,13 @@ class MifareClassicRecovery {
       this.isMifareClassicEV1 = false,
       List<ChameleonKeyCheckmark>? checkMarks,
       List<Uint8List>? validKeys,
+      List<Uint8List>? readableData,
       List<Uint8List>? cardData})
       : checkMarks =
             checkMarks ?? List.generate(80, (_) => ChameleonKeyCheckmark.none),
         validKeys = validKeys ?? List.generate(80, (_) => Uint8List(0)),
+        readableData =
+            readableData ?? List.generate(80, (_) => Uint8List(0)),
         cardData = cardData ?? List.generate(256, (_) => Uint8List(0)) {
     initializeEV1();
   }
@@ -121,6 +125,7 @@ class MifareClassicRecovery {
     if (await _canUseKeyBForMemoryAccess(sector, keyB)) {
       setKeyAsFound(sector, 1, keyB);
     } else {
+      readableData[sector + 40] = keyB;
       checkMarks[sector + 40] = ChameleonKeyCheckmark.readable;
       update();
     }
@@ -751,6 +756,7 @@ class MifareClassicRecovery {
   void setKeyAsFound(int sector, int keyType, Uint8List key) {
     checkMarks[sector + (keyType * 40)] = ChameleonKeyCheckmark.found;
     validKeys[sector + (keyType * 40)] = key;
+    readableData[sector + (keyType * 40)] = Uint8List(0);
     update();
   }
 

--- a/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
@@ -74,8 +74,12 @@ class MifareClassicRecovery {
         checkMark == ChameleonKeyCheckmark.disabled;
   }
 
-  bool _permissionAllowsKeyB(int permission) {
-    return permission == 2 || permission == 3;
+  Future<bool> _canUseKeyBForMemoryAccess(
+      int sector, Uint8List keyB) async {
+    final trailerBlock = mfClassicGetSectorTrailerBlockBySector(sector);
+    final block =
+        await appState.communicator!.mf1ReadBlock(trailerBlock, 0x61, keyB);
+    return block.length == 16;
   }
 
   Future<void> _resolveReadableKeyB(int sector, Uint8List keyA) async {
@@ -110,39 +114,11 @@ class MifareClassicRecovery {
     }
 
     final keyB = Uint8List.fromList(block.sublist(10, 16));
-    bool keyBReadSucceeded = false;
 
     // A readable Key B is normally data rather than an authentication key.
     // Some compatible cards nevertheless accept those same bytes as Key B.
-    // Verify that behavior with a non-destructive memory read before deciding
-    // whether to store the bytes as an authentication key.
-    for (var dataBlock = 0; dataBlock < 3; dataBlock++) {
-      final dataPermissions = MifareClassicDumpAnalyzer.dataAccessPermissions(
-          accessConditions[dataBlock]);
-      if (!_permissionAllowsKeyB(dataPermissions[0])) {
-        continue;
-      }
-
-      final testBlock =
-          mfClassicGetFirstBlockCountBySector(sector) + dataBlock;
-      final testData =
-          await appState.communicator!.mf1ReadBlock(testBlock, 0x61, keyB);
-      if (testData.length == 16) {
-        keyBReadSucceeded = true;
-        break;
-      }
-    }
-
-    // If no data block offers a safe Key-B read, the trailer itself can be
-    // used when its access bits are readable with Key B.
-    if (!keyBReadSucceeded &&
-        _permissionAllowsKeyB(trailerPermissions[1][0])) {
-      final testData =
-          await appState.communicator!.mf1ReadBlock(trailerBlock, 0x61, keyB);
-      keyBReadSucceeded = testData.length == 16;
-    }
-
-    if (keyBReadSucceeded) {
+    // Verify an actual memory operation before storing it as a valid key.
+    if (await _canUseKeyBForMemoryAccess(sector, keyB)) {
       setKeyAsFound(sector, 1, keyB);
     } else {
       checkMarks[sector + 40] = ChameleonKeyCheckmark.readable;
@@ -153,7 +129,6 @@ class MifareClassicRecovery {
   Future<bool> checkKeysOnSector(
       List<Uint8List> keys, int keyType, int sector) async {
     state = localizations.checking_keys(keys.length);
-    Uint8List? key;
     keyCheckProgress = null;
     int chunkSize =
         appState.connector!.connectionType == ConnectionType.ble ? 32 : 64;
@@ -166,12 +141,26 @@ class MifareClassicRecovery {
     int totalChunks = keys.partition(chunkSize).length;
 
     for (var chunk in keys.partition(chunkSize)) {
-      key = await appState.communicator!.mf1AuthMultipleKeys(
-          mfClassicGetSectorTrailerBlockBySector(sector),
-          0x60 + keyType,
-          chunk);
+      final remainingKeys = List<Uint8List>.from(chunk);
 
-      if (key != null) {
+      while (remainingKeys.isNotEmpty) {
+        final key = await appState.communicator!.mf1AuthMultipleKeys(
+            mfClassicGetSectorTrailerBlockBySector(sector),
+            0x60 + keyType,
+            remainingKeys);
+
+        if (key == null) {
+          break;
+        }
+
+        if (keyType == 1 &&
+            !await _canUseKeyBForMemoryAccess(sector, key)) {
+          final rejectedKey = bytesToHex(key);
+          remainingKeys
+              .removeWhere((candidate) => bytesToHex(candidate) == rejectedKey);
+          continue;
+        }
+
         setKeyAsFound(sector, keyType, key);
 
         if (keyType == 0) {
@@ -181,7 +170,9 @@ class MifareClassicRecovery {
         keyCheckProgress = null;
         await recheckKey(key, sector);
         return true;
-      } else if (totalChunks > 10) {
+      }
+
+      if (totalChunks > 10) {
         keyCheckProgress = (keyCheckProgress ?? 0) + 1 / totalChunks;
         update();
       }
@@ -223,11 +214,14 @@ class MifareClassicRecovery {
               "Checking found key ${bytesToHex(key)} on sector $sector, key type $keyType");
           setCheckingSector(sector, keyType);
 
-          if (await appState.communicator!.mf1Auth(
+          final authenticated = await appState.communicator!.mf1Auth(
               mfClassicGetSectorTrailerBlockBySector(sector),
               0x60 + keyType,
-              key)) {
-            // Found valid key
+              key);
+
+          if (authenticated &&
+              (keyType == 0 ||
+                  await _canUseKeyBForMemoryAccess(sector, key))) {
             setKeyAsFound(sector, keyType, key);
             if (keyType == 0) {
               await _resolveReadableKeyB(sector, key);

--- a/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
@@ -74,13 +74,18 @@ class MifareClassicRecovery {
         checkMark == ChameleonKeyCheckmark.disabled;
   }
 
-  Future<void> _markReadableKeyB(int sector, Uint8List keyA) async {
+  bool _permissionAllowsKeyB(int permission) {
+    return permission == 2 || permission == 3;
+  }
+
+  Future<void> _resolveReadableKeyB(int sector, Uint8List keyA) async {
     if (_isResolvedKeyState(sector, 1)) {
       return;
     }
 
-    final block = await appState.communicator!.mf1ReadBlock(
-        mfClassicGetSectorTrailerBlockBySector(sector), 0x60, keyA);
+    final trailerBlock = mfClassicGetSectorTrailerBlockBySector(sector);
+    final block =
+        await appState.communicator!.mf1ReadBlock(trailerBlock, 0x60, keyA);
 
     if (block.length != 16) {
       return;
@@ -93,10 +98,53 @@ class MifareClassicRecovery {
       return;
     }
 
-    final keyBPermissions = MifareClassicDumpAnalyzer.trailerAccessPermissions(
-        accessConditions[3])[2];
+    final trailerPermissions =
+        MifareClassicDumpAnalyzer.trailerAccessPermissions(
+            accessConditions[3]);
+    final keyBReadPermission = trailerPermissions[2][0];
 
-    if (keyBPermissions[0] == 1 || keyBPermissions[0] == 3) {
+    // Key B is only available in the card-returned trailer bytes when Key A
+    // is permitted to read that field.
+    if (keyBReadPermission != 1 && keyBReadPermission != 3) {
+      return;
+    }
+
+    final keyB = Uint8List.fromList(block.sublist(10, 16));
+    bool keyBReadSucceeded = false;
+
+    // A readable Key B is normally data rather than an authentication key.
+    // Some compatible cards nevertheless accept those same bytes as Key B.
+    // Verify that behavior with a non-destructive memory read before deciding
+    // whether to store the bytes as an authentication key.
+    for (var dataBlock = 0; dataBlock < 3; dataBlock++) {
+      final dataPermissions = MifareClassicDumpAnalyzer.dataAccessPermissions(
+          accessConditions[dataBlock]);
+      if (!_permissionAllowsKeyB(dataPermissions[0])) {
+        continue;
+      }
+
+      final testBlock =
+          mfClassicGetFirstBlockCountBySector(sector) + dataBlock;
+      final testData =
+          await appState.communicator!.mf1ReadBlock(testBlock, 0x61, keyB);
+      if (testData.length == 16) {
+        keyBReadSucceeded = true;
+        break;
+      }
+    }
+
+    // If no data block offers a safe Key-B read, the trailer itself can be
+    // used when its access bits are readable with Key B.
+    if (!keyBReadSucceeded &&
+        _permissionAllowsKeyB(trailerPermissions[1][0])) {
+      final testData =
+          await appState.communicator!.mf1ReadBlock(trailerBlock, 0x61, keyB);
+      keyBReadSucceeded = testData.length == 16;
+    }
+
+    if (keyBReadSucceeded) {
+      setKeyAsFound(sector, 1, keyB);
+    } else {
       checkMarks[sector + 40] = ChameleonKeyCheckmark.readable;
       update();
     }
@@ -127,7 +175,7 @@ class MifareClassicRecovery {
         setKeyAsFound(sector, keyType, key);
 
         if (keyType == 0) {
-          await _markReadableKeyB(sector, key);
+          await _resolveReadableKeyB(sector, key);
         }
 
         keyCheckProgress = null;
@@ -182,7 +230,7 @@ class MifareClassicRecovery {
             // Found valid key
             setKeyAsFound(sector, keyType, key);
             if (keyType == 0) {
-              await _markReadableKeyB(sector, key);
+              await _resolveReadableKeyB(sector, key);
             }
           } else {
             setMissingSector(sector, keyType);

--- a/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/recovery.dart
@@ -4,6 +4,7 @@ import 'package:chameleonultragui/connector/serial_abstract.dart';
 import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
 import 'package:chameleonultragui/helpers/definitions.dart';
 import 'package:chameleonultragui/helpers/general.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/dump_analyzer.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/general.dart';
 import 'package:chameleonultragui/main.dart';
 import 'package:chameleonultragui/recovery/recovery.dart';
@@ -24,7 +25,7 @@ extension PartitionList<E> on List<E> {
   }
 }
 
-enum ChameleonKeyCheckmark { none, found, checking, disabled }
+enum ChameleonKeyCheckmark { none, found, readable, checking, disabled }
 
 class MifareClassicRecovery {
   late ChameleonGUIState appState;
@@ -66,6 +67,41 @@ class MifareClassicRecovery {
     initializeEV1();
   }
 
+  bool _isResolvedKeyState(int sector, int keyType) {
+    final checkMark = getSectorState(sector, keyType);
+    return checkMark == ChameleonKeyCheckmark.found ||
+        checkMark == ChameleonKeyCheckmark.readable ||
+        checkMark == ChameleonKeyCheckmark.disabled;
+  }
+
+  Future<void> _markReadableKeyB(int sector, Uint8List keyA) async {
+    if (_isResolvedKeyState(sector, 1)) {
+      return;
+    }
+
+    final block = await appState.communicator!.mf1ReadBlock(
+        mfClassicGetSectorTrailerBlockBySector(sector), 0x60, keyA);
+
+    if (block.length != 16) {
+      return;
+    }
+
+    final accessConditions = MifareClassicDumpAnalyzer.accessConditionValues(
+        bytesToHex(block.sublist(6, 9)));
+
+    if (accessConditions == null) {
+      return;
+    }
+
+    final keyBPermissions = MifareClassicDumpAnalyzer.trailerAccessPermissions(
+        accessConditions[3])[2];
+
+    if (keyBPermissions[0] == 1 || keyBPermissions[0] == 3) {
+      checkMarks[sector + 40] = ChameleonKeyCheckmark.readable;
+      update();
+    }
+  }
+
   Future<bool> checkKeysOnSector(
       List<Uint8List> keys, int keyType, int sector) async {
     state = localizations.checking_keys(keys.length);
@@ -74,46 +110,32 @@ class MifareClassicRecovery {
     int chunkSize =
         appState.connector!.connectionType == ConnectionType.ble ? 32 : 64;
 
-    if (getSectorState(sector, keyType) != ChameleonKeyCheckmark.found &&
-        getSectorState(sector, keyType) != ChameleonKeyCheckmark.disabled) {
-      setCheckingSector(sector, keyType);
-      int totalChunks = keys.partition(chunkSize).length;
-
-      for (var chunk in keys.partition(chunkSize)) {
-        key = await appState.communicator!.mf1AuthMultipleKeys(
-            mfClassicGetSectorTrailerBlockBySector(sector),
-            0x60 + keyType,
-            chunk);
-        if (key != null) {
-          setKeyAsFound(sector, keyType, key);
-          keyCheckProgress = null;
-          await recheckKey(key, sector);
-          return true;
-        } else if (totalChunks > 10) {
-          keyCheckProgress = (keyCheckProgress ?? 0) + 1 / totalChunks;
-          update();
-        }
-      }
-
-      if (key == null) {
-        setMissingSector(sector, keyType);
-      }
+    if (_isResolvedKeyState(sector, keyType)) {
+      return getSectorState(sector, keyType) != ChameleonKeyCheckmark.disabled;
     }
 
-    if (keyType == 0 &&
-        getSectorState(sector, 0) == ChameleonKeyCheckmark.found &&
-        getSectorState(sector, 1) != ChameleonKeyCheckmark.found &&
-        getSectorState(sector, 1) != ChameleonKeyCheckmark.disabled &&
-        key != null) {
-      Uint8List block = await appState.communicator!.mf1ReadBlock(
-          mfClassicGetSectorTrailerBlockBySector(sector), 0x60 + keyType, key);
-      if (block.length == 16) {
-        Uint8List bKey = block.sublist(10);
-        if (bytesToHex(bKey) != bytesToHex(Uint8List(6))) {
-          keyCheckProgress = null;
-          await recheckKey(key, sector);
-          return true;
+    setCheckingSector(sector, keyType);
+    int totalChunks = keys.partition(chunkSize).length;
+
+    for (var chunk in keys.partition(chunkSize)) {
+      key = await appState.communicator!.mf1AuthMultipleKeys(
+          mfClassicGetSectorTrailerBlockBySector(sector),
+          0x60 + keyType,
+          chunk);
+
+      if (key != null) {
+        setKeyAsFound(sector, keyType, key);
+
+        if (keyType == 0) {
+          await _markReadableKeyB(sector, key);
         }
+
+        keyCheckProgress = null;
+        await recheckKey(key, sector);
+        return true;
+      } else if (totalChunks > 10) {
+        keyCheckProgress = (keyCheckProgress ?? 0) + 1 / totalChunks;
+        update();
       }
     }
 
@@ -159,6 +181,9 @@ class MifareClassicRecovery {
               key)) {
             // Found valid key
             setKeyAsFound(sector, keyType, key);
+            if (keyType == 0) {
+              await _markReadableKeyB(sector, key);
+            }
           } else {
             setMissingSector(sector, keyType);
           }
@@ -206,8 +231,7 @@ class MifareClassicRecovery {
                 isEV1: isMifareClassicEV1);
         sector++) {
       for (var keyType = 0; keyType < 2; keyType++) {
-        if (getSectorState(sector, keyType) != ChameleonKeyCheckmark.found &&
-            getSectorState(sector, keyType) != ChameleonKeyCheckmark.disabled) {
+        if (!_isResolvedKeyState(sector, keyType)) {
           allKeysExists = false;
         }
       }
@@ -497,8 +521,7 @@ class MifareClassicRecovery {
                   backdoorInfo.$2.nonces[sector].nt,
                   backdoorInfo.$3.nonces[sector].nt);
 
-              if (checkMarks[sector + 40] != ChameleonKeyCheckmark.found &&
-                  checkMarks[sector + 40] != ChameleonKeyCheckmark.disabled &&
+              if (!_isResolvedKeyState(sector, 1) &&
                   await checkKeysOnSector(
                       mfClassicConvertKeys(filtered.$2.reversed.toList()),
                       1,
@@ -559,8 +582,7 @@ class MifareClassicRecovery {
                 isEV1: isMifareClassicEV1);
         sector++) {
       for (var keyType = 0; keyType < 2; keyType++) {
-        if (getSectorState(sector, keyType) != ChameleonKeyCheckmark.found &&
-            getSectorState(sector, keyType) != ChameleonKeyCheckmark.disabled) {
+        if (!_isResolvedKeyState(sector, keyType)) {
           allKeysExists = false;
         }
       }

--- a/chameleonultragui/lib/helpers/mifare_classic/write/gen2.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/write/gen2.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:chameleonultragui/helpers/definitions.dart';
 import 'package:chameleonultragui/helpers/general.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/dump_analyzer.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/general.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/recovery.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/write/base.dart';
@@ -65,6 +66,53 @@ class MifareClassicGen2WriteHelper extends BaseMifareClassicWriteHelper {
     }
 
     return false;
+  }
+
+  Future<bool> _verifyTrailerWrite(
+      int block, Uint8List expectedTrailer) async {
+    if (expectedTrailer.length != 16) {
+      return false;
+    }
+
+    try {
+      final trailer = await communicator.mf1ReadBlock(
+          block, 0x60, expectedTrailer.sublist(0, 6));
+
+      if (trailer.length != 16) {
+        return false;
+      }
+
+      for (var index = 6; index < 10; index++) {
+        if (trailer[index] != expectedTrailer[index]) {
+          return false;
+        }
+      }
+
+      final accessConditions =
+          MifareClassicDumpAnalyzer.accessConditionValues(
+              bytesToHex(expectedTrailer.sublist(6, 9)));
+      if (accessConditions == null) {
+        return false;
+      }
+
+      final keyB = expectedTrailer.sublist(10, 16);
+      final keyBIsReadable =
+          const <int>{0, 2, 4}.contains(accessConditions[3]);
+
+      if (keyBIsReadable) {
+        for (var index = 10; index < 16; index++) {
+          if (trailer[index] != expectedTrailer[index]) {
+            return false;
+          }
+        }
+
+        return true;
+      }
+
+      return await communicator.mf1Auth(block, 0x61, keyB);
+    } catch (_) {
+      return false;
+    }
   }
 
   @override
@@ -131,9 +179,11 @@ class MifareClassicGen2WriteHelper extends BaseMifareClassicWriteHelper {
     for (var sector = 0; sector < mfClassicGetSectorCount(type); sector++) {
       var block = mfClassicGetSectorTrailerBlockBySector(sector);
       if (data.length > block && data[block].isNotEmpty) {
-        cleanSectors[sector] = await writeBlockModifier(
-            card, block, data[block],
-            tryBothKeys: true);
+        if (await writeBlockModifier(card, block, data[block],
+            tryBothKeys: true)) {
+          cleanSectors[sector] =
+              await _verifyTrailerWrite(block, data[block]);
+        }
         if (cleanSectors[sector]) {
           // Update keys to match the newly written trailer,
           // so subsequent data block writes use the correct keys.

--- a/chameleonultragui/lib/helpers/mifare_classic/write/gen2.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/write/gen2.dart
@@ -36,11 +36,14 @@ class MifareClassicGen2WriteHelper extends BaseMifareClassicWriteHelper {
     for (var sector = 0;
         sector < mfClassicGetSectorCount(type, isEV1: isEV1);
         sector++) {
-      for (var keyType = 0; keyType < 2; keyType++) {
-        if (recovery.checkMarks[sector + (keyType * 40)] !=
-            ChameleonKeyCheckmark.found) {
-          return false;
-        }
+      if (recovery.checkMarks[sector] != ChameleonKeyCheckmark.found) {
+        return false;
+      }
+
+      final keyBState = recovery.checkMarks[sector + 40];
+      if (keyBState != ChameleonKeyCheckmark.found &&
+          keyBState != ChameleonKeyCheckmark.readable) {
+        return false;
       }
     }
 

--- a/chameleonultragui/lib/helpers/mifare_classic/write/gen2.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/write/gen2.dart
@@ -88,19 +88,18 @@ class MifareClassicGen2WriteHelper extends BaseMifareClassicWriteHelper {
     }
 
     if (tryBothKeys) {
-      if (await communicator.mf1WriteBlock(
-          block,
-          0x61,
-          (useGenericKey)
-              ? gMifareClassicKeys[0]
-              : recovery.validKeys[40 + mfClassicGetSectorByBlock(block)],
-          data)) {
-        return true;
-      }
+      final keyB =
+          recovery.validKeys[40 + mfClassicGetSectorByBlock(block)];
 
       if (useGenericKey) {
-        if (await communicator.mf1WriteBlock(block, 0x61,
-            recovery.validKeys[40 + mfClassicGetSectorByBlock(block)], data)) {
+        if (await communicator.mf1WriteBlock(
+            block, 0x61, gMifareClassicKeys[0], data)) {
+          return true;
+        }
+      }
+
+      if (keyB.length == 6) {
+        if (await communicator.mf1WriteBlock(block, 0x61, keyB, data)) {
           return true;
         }
       }

--- a/chameleonultragui/lib/helpers/mifare_classic/write/gen3.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/write/gen3.dart
@@ -37,11 +37,14 @@ class MifareClassicGen3WriteHelper extends MifareClassicGen2WriteHelper {
     for (var sector = 0;
         sector < mfClassicGetSectorCount(type, isEV1: isEV1);
         sector++) {
-      for (var keyType = 0; keyType < 2; keyType++) {
-        if (recovery.checkMarks[sector + (keyType * 40)] !=
-            ChameleonKeyCheckmark.found) {
-          return false;
-        }
+      if (recovery.checkMarks[sector] != ChameleonKeyCheckmark.found) {
+        return false;
+      }
+
+      final keyBState = recovery.checkMarks[sector + 40];
+      if (keyBState != ChameleonKeyCheckmark.found &&
+          keyBState != ChameleonKeyCheckmark.readable) {
+        return false;
       }
     }
 

--- a/chameleonultragui/lib/helpers/mifare_classic/write/gen3.dart
+++ b/chameleonultragui/lib/helpers/mifare_classic/write/gen3.dart
@@ -2,8 +2,6 @@ import 'dart:typed_data';
 
 import 'package:chameleonultragui/helpers/definitions.dart';
 import 'package:chameleonultragui/helpers/general.dart';
-import 'package:chameleonultragui/helpers/mifare_classic/general.dart';
-import 'package:chameleonultragui/helpers/mifare_classic/recovery.dart';
 import 'package:chameleonultragui/helpers/mifare_classic/write/gen2.dart';
 import 'package:chameleonultragui/sharedprefsprovider.dart';
 
@@ -30,25 +28,6 @@ class MifareClassicGen3WriteHelper extends MifareClassicGen2WriteHelper {
     } catch (_) {
       return false;
     }
-  }
-
-  @override
-  bool isReady() {
-    for (var sector = 0;
-        sector < mfClassicGetSectorCount(type, isEV1: isEV1);
-        sector++) {
-      if (recovery.checkMarks[sector] != ChameleonKeyCheckmark.found) {
-        return false;
-      }
-
-      final keyBState = recovery.checkMarks[sector + 40];
-      if (keyBState != ChameleonKeyCheckmark.found &&
-          keyBState != ChameleonKeyCheckmark.readable) {
-        return false;
-      }
-    }
-
-    return true;
   }
 
   @override

--- a/chameleonultragui/test/gen2_write_test.dart
+++ b/chameleonultragui/test/gen2_write_test.dart
@@ -1,0 +1,392 @@
+import 'dart:typed_data';
+
+import 'package:chameleonultragui/bridge/chameleon.dart';
+import 'package:chameleonultragui/generated/i18n/app_localizations.dart';
+import 'package:chameleonultragui/helpers/definitions.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/general.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/recovery.dart';
+import 'package:chameleonultragui/helpers/mifare_classic/write/gen2.dart';
+import 'package:chameleonultragui/main.dart';
+import 'package:chameleonultragui/sharedprefsprovider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+class _FakeChameleonCommunicator extends ChameleonCommunicator {
+  final List<Uint8List> memory;
+  final bool ignoreSector0TrailerWrite;
+
+  _FakeChameleonCommunicator(
+    this.memory, {
+    this.ignoreSector0TrailerWrite = true,
+  }) : super(Logger());
+
+  @override
+  Future<CardData?> scan14443aTag() async {
+    return CardData(
+      uid: Uint8List.fromList([0x12, 0x34, 0x56, 0x78]),
+      sak: 0x08,
+      atqa: Uint8List.fromList([0x00, 0x04]),
+      ats: Uint8List(0),
+    );
+  }
+
+  @override
+  Future<bool> mf1WriteBlock(
+      int block, int keyType, Uint8List key, Uint8List data) async {
+    // Reproduce the observed failure mode: the device reports success for
+    // sector 0's trailer write even though the protected trailer is unchanged.
+    if (block == 3 && ignoreSector0TrailerWrite) {
+      return true;
+    }
+
+    memory[block] = Uint8List.fromList(data);
+    return true;
+  }
+
+  @override
+  Future<Uint8List> mf1ReadBlock(int block, int keyType, Uint8List key) async {
+    final data = Uint8List.fromList(memory[block]);
+
+    if (block == 3) {
+      // Key A is never returned when reading a sector trailer.
+      data.fillRange(0, 6, 0);
+    }
+
+    return data;
+  }
+
+  @override
+  Future<bool> mf1Auth(int block, int keyType, Uint8List key) async {
+    if (keyType != 0x61 || key.length != 6) {
+      return false;
+    }
+
+    final storedKeyB = memory[block].sublist(10, 16);
+    for (var index = 0; index < 6; index++) {
+      if (storedKeyB[index] != key[index]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}
+
+Uint8List _keyA(int sector) =>
+    Uint8List.fromList([0xA0, 0xA1, 0xA2, 0xA3, 0xA4, sector]);
+
+Uint8List _readableKeyB(int sector) =>
+    Uint8List.fromList([0xE0, 0xE1, 0xE2, 0xE3, 0xE4, sector]);
+
+Uint8List _authKeyB(int sector) =>
+    Uint8List.fromList([0xB0, 0xB1, 0xB2, 0xB3, 0xB4, sector]);
+
+Uint8List _sourceTrailer(int sector) => Uint8List.fromList([
+      ..._keyA(sector),
+      0xFF,
+      0x07,
+      0x80,
+      0x69,
+      ..._readableKeyB(sector),
+    ]);
+
+void main() {
+  testWidgets(
+      'Gen2 write fails when trailer write is acknowledged but not applied',
+      (tester) async {
+    AppLocalizations? localizations;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            localizations = AppLocalizations.of(context);
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+
+    expect(localizations, isNotNull);
+
+    final source = List<Uint8List>.generate(
+      4,
+      (block) => Uint8List.fromList(List<int>.filled(16, block)),
+    );
+
+    source[3] = _sourceTrailer(0);
+
+    // Source payload sentinel.
+    source[1] = Uint8List.fromList(List<int>.filled(16, 0x01));
+
+    final target = source
+        .map((block) => Uint8List.fromList(block))
+        .toList(growable: false);
+
+    // Target payload differs so we can prove ordinary writes still occur.
+    target[1] = Uint8List.fromList(List<int>.filled(16, 0xA5));
+
+    // Sector 0 trailer condition 010:
+    // data blocks remain writable, but the sector trailer is not writable.
+    target[3] = Uint8List.fromList([
+      ..._keyA(0),
+      0x7F,
+      0x0F,
+      0x08,
+      0x69,
+      ..._readableKeyB(0),
+    ]);
+
+    final communicator = _FakeChameleonCommunicator(target);
+
+    final appState = ChameleonGUIState(SharedPreferencesProvider())
+      ..communicator = communicator
+      ..log = Logger();
+
+    final checkMarks =
+        List.filled(80, ChameleonKeyCheckmark.none, growable: false);
+    final validKeys = List.generate(80, (_) => Uint8List(0), growable: false);
+    final readableData =
+        List.generate(80, (_) => Uint8List(0), growable: false);
+
+    for (var sector = 0; sector < 16; sector++) {
+      checkMarks[sector] = ChameleonKeyCheckmark.found;
+      validKeys[sector] = _keyA(sector);
+
+      checkMarks[40 + sector] = ChameleonKeyCheckmark.readable;
+      readableData[40 + sector] = _readableKeyB(sector);
+    }
+
+    final recovery = MifareClassicRecovery(
+      appState: appState,
+      update: () {},
+      localizations: localizations!,
+      mifareClassicType: MifareClassicType.m1k,
+      checkMarks: checkMarks,
+      validKeys: validKeys,
+      readableData: readableData,
+    );
+
+    final helper =
+        MifareClassicGen2WriteHelper(communicator, recovery: recovery);
+
+    final card = CardSave(
+      uid: '12345678',
+      name: 'Gen2 ACL verification fixture',
+      tag: TagType.mifare1K,
+      sak: 0x08,
+      atqa: Uint8List.fromList([0x00, 0x04]),
+      data: source,
+    );
+
+    final result = await tester.runAsync(() => helper.writeData(card, (_) {}));
+
+    // Ordinary data write succeeded.
+    expect(target[1], orderedEquals(source[1]));
+
+    // The protected sector trailer did not actually change.
+    expect(
+      target[3],
+      orderedEquals([
+        ..._keyA(0),
+        0x7F,
+        0x0F,
+        0x08,
+        0x69,
+        ..._readableKeyB(0),
+      ]),
+    );
+
+    // An incomplete clone must not be reported as a complete success.
+    expect(result, isFalse);
+  });
+
+  testWidgets('Gen2 write succeeds when trailer write is applied',
+      (tester) async {
+    AppLocalizations? localizations;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            localizations = AppLocalizations.of(context);
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+
+    expect(localizations, isNotNull);
+
+    final source = List<Uint8List>.generate(
+      4,
+      (block) => Uint8List.fromList(List<int>.filled(16, block)),
+    );
+
+    source[3] = _sourceTrailer(0);
+
+    source[1] = Uint8List.fromList(List<int>.filled(16, 0x01));
+
+    final target = source
+        .map((block) => Uint8List.fromList(block))
+        .toList(growable: false);
+
+    target[1] = Uint8List.fromList(List<int>.filled(16, 0xA5));
+
+    // Give sector 0 a different GPB so this test proves the trailer itself
+    // was actually updated, not merely acknowledged.
+    target[3] = Uint8List.fromList([
+      ..._keyA(0),
+      0xFF,
+      0x07,
+      0x80,
+      0x68,
+      ..._readableKeyB(0),
+    ]);
+
+    final communicator = _FakeChameleonCommunicator(
+      target,
+      ignoreSector0TrailerWrite: false,
+    );
+
+    final appState = ChameleonGUIState(SharedPreferencesProvider())
+      ..communicator = communicator
+      ..log = Logger();
+
+    final checkMarks =
+        List.filled(80, ChameleonKeyCheckmark.none, growable: false);
+    final validKeys = List.generate(80, (_) => Uint8List(0), growable: false);
+    final readableData =
+        List.generate(80, (_) => Uint8List(0), growable: false);
+
+    for (var sector = 0; sector < 16; sector++) {
+      checkMarks[sector] = ChameleonKeyCheckmark.found;
+      validKeys[sector] = _keyA(sector);
+
+      checkMarks[40 + sector] = ChameleonKeyCheckmark.readable;
+      readableData[40 + sector] = _readableKeyB(sector);
+    }
+
+    final recovery = MifareClassicRecovery(
+      appState: appState,
+      update: () {},
+      localizations: localizations!,
+      mifareClassicType: MifareClassicType.m1k,
+      checkMarks: checkMarks,
+      validKeys: validKeys,
+      readableData: readableData,
+    );
+
+    final helper =
+        MifareClassicGen2WriteHelper(communicator, recovery: recovery);
+
+    final card = CardSave(
+      uid: '12345678',
+      name: 'Gen2 successful write fixture',
+      tag: TagType.mifare1K,
+      sak: 0x08,
+      atqa: Uint8List.fromList([0x00, 0x04]),
+      data: source,
+    );
+
+    final result = await tester.runAsync(() => helper.writeData(card, (_) {}));
+
+    expect(target[1], orderedEquals(source[1]));
+    expect(target[3], orderedEquals(source[3]));
+    expect(result, isTrue);
+  });
+
+  testWidgets('Gen2 write verifies protected Key B by authentication',
+      (tester) async {
+    AppLocalizations? localizations;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            localizations = AppLocalizations.of(context);
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+
+    expect(localizations, isNotNull);
+
+    final source = List<Uint8List>.generate(
+      4,
+      (block) => Uint8List.fromList(List<int>.filled(16, block)),
+    );
+
+    source[1] = Uint8List.fromList(List<int>.filled(16, 0x01));
+    source[3] = Uint8List.fromList([
+      ..._keyA(0),
+      0xF7,
+      0x8F,
+      0x00,
+      0x69,
+      ..._authKeyB(0),
+    ]);
+
+    final target = source
+        .map((block) => Uint8List.fromList(block))
+        .toList(growable: false);
+
+    target[1] = Uint8List.fromList(List<int>.filled(16, 0xA5));
+
+    final communicator = _FakeChameleonCommunicator(
+      target,
+      ignoreSector0TrailerWrite: false,
+    );
+
+    final appState = ChameleonGUIState(SharedPreferencesProvider())
+      ..communicator = communicator
+      ..log = Logger();
+
+    final checkMarks =
+        List.filled(80, ChameleonKeyCheckmark.none, growable: false);
+    final validKeys = List.generate(80, (_) => Uint8List(0), growable: false);
+    final readableData =
+        List.generate(80, (_) => Uint8List(0), growable: false);
+
+    checkMarks[0] = ChameleonKeyCheckmark.found;
+    validKeys[0] = _keyA(0);
+    checkMarks[40] = ChameleonKeyCheckmark.found;
+    validKeys[40] = _authKeyB(0);
+
+    final recovery = MifareClassicRecovery(
+      appState: appState,
+      update: () {},
+      localizations: localizations!,
+      mifareClassicType: MifareClassicType.m1k,
+      checkMarks: checkMarks,
+      validKeys: validKeys,
+      readableData: readableData,
+    );
+
+    final helper =
+        MifareClassicGen2WriteHelper(communicator, recovery: recovery);
+
+    final card = CardSave(
+      uid: '12345678',
+      name: 'Gen2 protected Key B fixture',
+      tag: TagType.mifare1K,
+      sak: 0x08,
+      atqa: Uint8List.fromList([0x00, 0x04]),
+      data: source,
+    );
+
+    final result = await tester.runAsync(() => helper.writeData(card, (_) {}));
+
+    expect(target[1], orderedEquals(source[1]));
+    expect(target[3], orderedEquals(source[3]));
+    expect(result, isTrue);
+  });
+}

--- a/chameleonultragui/test/key_check_marks_test.dart
+++ b/chameleonultragui/test/key_check_marks_test.dart
@@ -13,6 +13,8 @@ void main() {
     final checkMarks =
         List.filled(80, ChameleonKeyCheckmark.none, growable: false);
     final validKeys = List.generate(80, (_) => Uint8List(0), growable: false);
+    final readableData =
+        List.generate(80, (_) => Uint8List(0), growable: false);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -24,6 +26,7 @@ void main() {
               return KeyCheckMarks(
                 checkMarks: checkMarks,
                 validKeys: validKeys,
+                readableData: readableData,
                 checkmarkCount: 3,
                 checkmarkPerRow: 3,
                 onCheckmarkChanged: (index, newValue) {

--- a/chameleonultragui/test/key_check_marks_test.dart
+++ b/chameleonultragui/test/key_check_marks_test.dart
@@ -65,4 +65,35 @@ void main() {
     expect(checkMarks[1], ChameleonKeyCheckmark.none);
     expect(checkMarks[2], ChameleonKeyCheckmark.none);
   });
+
+  testWidgets('readable key B displays visibility icon and readable data',
+      (tester) async {
+    final checkMarks =
+        List.filled(80, ChameleonKeyCheckmark.none, growable: false);
+    final validKeys = List.generate(80, (_) => Uint8List(0), growable: false);
+    final readableData =
+        List.generate(80, (_) => Uint8List(0), growable: false);
+
+    checkMarks[0] = ChameleonKeyCheckmark.readable;
+    readableData[0] = Uint8List.fromList([0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0x00]);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: KeyCheckMarks(
+            checkMarks: checkMarks,
+            validKeys: validKeys,
+            readableData: readableData,
+            checkmarkCount: 1,
+            checkmarkPerRow: 1,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.visibility), findsOneWidget);
+    expect(find.byTooltip('E0E1E2E3E400'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary

Fix MIFARE Classic recovery handling for sector trailers where Key B is readable as data instead of necessarily being usable as an authentication key.

The recovery flow now:
- decodes trailer access conditions before classifying readable Key B bytes
- verifies whether readable Key B bytes can actually perform memory access before marking them as a found key
- tracks readable-only Key B data separately from authentication keys
- treats readable Key B as a resolved state so recovery does not continue attacking it
- displays readable-only Key B data with a blue visibility icon and tooltip

The write flow now also:
- treats a found Key A plus a readable-only Key B as sufficient write readiness
- shares that readiness behavior between Gen2 and Gen3
- only attempts a recovered Key B write when the stored Key B is actually six bytes, while preserving the generic-Key-B fallback
- verifies an acknowledged Gen2/Gen3 sector-trailer write before treating that sector as clean or replacing the recovered keys
  - the expected Key A must successfully read the resulting trailer
  - access-condition bytes and GPB must match the requested trailer
  - readable Key B data is compared directly
  - protected Key B is verified by authentication
- briefly preserves the completed recovery state before transitioning to the write interface so readable/found key state remains visible

This also addresses the write-readiness behavior reported in #976, where readable Key B sectors could leave the Write action unavailable.

## Validation

Validated with automated tests, synthetic fixtures, and physical/emulated hardware cases:

- Flutter tests: 22/22 pass
- focused Gen2 trailer-write regressions: 3/3 pass
  - acknowledged-but-unapplied trailer write is detected and the overall write reports failure
  - an applied trailer with readable Key B data verifies successfully
  - an applied trailer with protected Key B verifies successfully by authentication
- `flutter analyze` for the modified/relevant recovery, write, UI, and Gen2 regression-test files: no issues
- Windows release build: pass
- synthetic MIFARE Classic Key-B state-matrix regression: expected 16/16 sector state pattern
  - readable-only Key B sectors show blue/readable
  - unresolved Key A control leaves readable B unresolved
  - protected missing Key B control remains unresolved
- physical Gen2/CUID clone: readable B values that also work for memory access are correctly classified as found keys
- original physical source card: same usable-readable-B behavior correctly classified as found keys
- Gen2 write-readiness regression for #976:
  - all Key A values found
  - protected odd-sector Key B values found
  - readable-only even-sector Key B values remain blue/readable
  - no unresolved sectors
  - Write action becomes enabled
- end-to-end Gen2 write test against a Proxmark3-emulated target:
  - target block 1 was changed to `A5` x16 before the write
  - the GUI completed the normal write successfully
  - emulator memory verified block 1 changed back to `01` x16
  - the same test passed again on the amended branch
- false-success regression reproduced against a Proxmark3-emulated ACL-010 target before the safeguard:
  - source requested sector 0 trailer ACL/GPB `FF 07 80 69`
  - target retained protected trailer ACL/GPB `7F 0F 08 69`
  - the Chameleon write command reported success for the trailer write
  - an ordinary data block was still modified
  - the GUI nevertheless reported the card write as successful
- the added trailer verification prevents that acknowledged-but-unapplied trailer write from being treated as a successful sector transition

This distinguishes readable trailer data from real authentication capability while still supporting compatible cards that accept the same readable bytes as Key B, and prevents the newly reachable write path from reporting complete success after a partial target modification.