### PR TITLE
feat: show selected card and type under write card steps

### DIFF
--- a/chameleonultragui/lib/gui/page/write_card.dart
+++ b/chameleonultragui/lib/gui/page/write_card.dart
@@ -313,6 +313,7 @@ class WriteCardPageState extends State<WriteCardPage> {
         steps: [
           Step(
             title: Text(localizations.select_saved_card_to_write),
+            subtitle: step > 0 && card != null ? Text(card!.name) : null,
             content: Card(
               child: ListTile(
                 title: Row(children: [
@@ -342,6 +343,9 @@ class WriteCardPageState extends State<WriteCardPage> {
           ),
           Step(
             title: Text(localizations.select_magic_card),
+            subtitle: step > 1 && helper != null
+                ? Text(typeLocalization[helper!.name]!)
+                : null,
             content: Card(
               child: ListTile(
                 title: (baseHelper != null)


### PR DESCRIPTION
In the card writing process, moving to the next step causes the previous selected options to become hidden, making it unclear which card dump or what card type has been selected. Subtitles provide a sense of confirmation for users.